### PR TITLE
feat(frontend): centralize event selection in sidebar

### DIFF
--- a/frontend/app/[locale]/(app)/characters/page.tsx
+++ b/frontend/app/[locale]/(app)/characters/page.tsx
@@ -1,7 +1,9 @@
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
+import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 import { eventsApi } from "@/utils/events-api";
+import { ACTIVE_EVENT_COOKIE_NAME } from "@/utils/active-event-cookie";
 import { CharacterLanding } from "@/components/characters/character-landing";
 
 export default async function CharactersLandingPage({
@@ -19,10 +21,16 @@ export default async function CharactersLandingPage({
         redirect(`/${locale}/login`);
     }
 
+    // Redirect to event-scoped page if an active event is set
+    const cookieStore = await cookies();
+    const activeEventId = cookieStore.get(ACTIVE_EVENT_COOKIE_NAME)?.value;
+    if (activeEventId) {
+        redirect(`/${locale}/characters/${activeEventId}`);
+    }
+
     // Fetch available events for the selector
     const token = session.access_token;
 
-    // Default to active events for the landing page selector
     let events: any[] = [];
     try {
         events = await eventsApi.listEvents(token, { includeArchived: false });

--- a/frontend/app/[locale]/(app)/layout.tsx
+++ b/frontend/app/[locale]/(app)/layout.tsx
@@ -1,6 +1,9 @@
+import { cookies } from "next/headers"
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/app-sidebar"
+import { ActiveEventProvider } from "@/components/active-event-context"
 import { createClient } from "@/utils/supabase/server"
+import { ACTIVE_EVENT_COOKIE_NAME } from "@/utils/active-event-cookie"
 import { Toaster } from "sonner"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5293"
@@ -19,18 +22,23 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         }
     }
 
+    const cookieStore = await cookies()
+    const activeEventId = cookieStore.get(ACTIVE_EVENT_COOKIE_NAME)?.value ?? null
+
     return (
         <SidebarProvider>
-            <AppSidebar isSystemAdmin={isSystemAdmin} />
-            <SidebarInset>
-                <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
-                    <SidebarTrigger />
-                </header>
-                <div className="min-w-0 flex-1 overflow-auto">
-                    {children}
-                </div>
-            </SidebarInset>
-            <Toaster position="top-right" closeButton richColors />
+            <ActiveEventProvider initialEventId={activeEventId}>
+                <AppSidebar isSystemAdmin={isSystemAdmin} />
+                <SidebarInset>
+                    <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+                        <SidebarTrigger />
+                    </header>
+                    <div className="min-w-0 flex-1 overflow-auto">
+                        {children}
+                    </div>
+                </SidebarInset>
+                <Toaster position="top-right" closeButton richColors />
+            </ActiveEventProvider>
         </SidebarProvider>
     )
 }

--- a/frontend/app/[locale]/(app)/narrative/page.tsx
+++ b/frontend/app/[locale]/(app)/narrative/page.tsx
@@ -1,7 +1,9 @@
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
+import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 import { eventsApi } from "@/utils/events-api";
+import { ACTIVE_EVENT_COOKIE_NAME } from "@/utils/active-event-cookie";
 import { NarrativeLanding } from "@/components/narrative/narrative-landing";
 
 export default async function NarrativeLandingPage({
@@ -17,6 +19,13 @@ export default async function NarrativeLandingPage({
 
     if (!session) {
         redirect(`/${locale}/login`);
+    }
+
+    // Redirect to event-scoped page if an active event is set
+    const cookieStore = await cookies();
+    const activeEventId = cookieStore.get(ACTIVE_EVENT_COOKIE_NAME)?.value;
+    if (activeEventId) {
+        redirect(`/${locale}/narrative/${activeEventId}`);
     }
 
     const token = session.access_token;

--- a/frontend/components/active-event-context.tsx
+++ b/frontend/components/active-event-context.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+    createContext,
+    useContext,
+    useState,
+    useEffect,
+    useCallback,
+    type ReactNode,
+} from "react";
+import { useParams } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { eventsApi, type EventListItemDto } from "@/utils/events-api";
+import {
+    setActiveEventCookie,
+    clearActiveEventCookie,
+} from "@/utils/active-event-cookie";
+
+type ActiveEventContextValue = {
+    activeEventId: string | null;
+    activeEvent: EventListItemDto | null;
+    events: EventListItemDto[];
+    setActiveEvent: (eventId: string | null) => void;
+    isLoading: boolean;
+};
+
+const ActiveEventContext = createContext<ActiveEventContextValue | null>(null);
+
+export function ActiveEventProvider({
+    initialEventId,
+    children,
+}: {
+    initialEventId: string | null;
+    children: ReactNode;
+}) {
+    const [activeEventId, setActiveEventId] = useState<string | null>(initialEventId);
+    const [events, setEvents] = useState<EventListItemDto[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const params = useParams();
+
+    // Fetch events on mount
+    useEffect(() => {
+        async function fetchEvents() {
+            const supabase = createClient();
+            const { data: { session } } = await supabase.auth.getSession();
+            if (!session) {
+                setIsLoading(false);
+                return;
+            }
+
+            try {
+                const eventList = await eventsApi.listEvents(
+                    session.access_token,
+                    { includeArchived: false }
+                );
+                setEvents(eventList);
+
+                // Validate initialEventId against fetched events
+                if (activeEventId && !eventList.find((e) => e.id === activeEventId)) {
+                    clearActiveEventCookie();
+                    setActiveEventId(null);
+                }
+            } catch (error) {
+                console.error("Failed to fetch events for context:", error);
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        fetchEvents();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // URL sync: URL is source of truth
+    const urlEventId = params?.eventId as string | undefined;
+    useEffect(() => {
+        if (urlEventId && urlEventId !== activeEventId) {
+            setActiveEventId(urlEventId);
+            setActiveEventCookie(urlEventId);
+        }
+    }, [urlEventId, activeEventId]);
+
+    const setActiveEvent = useCallback(
+        (eventId: string | null) => {
+            setActiveEventId(eventId);
+            if (eventId) {
+                setActiveEventCookie(eventId);
+            } else {
+                clearActiveEventCookie();
+            }
+        },
+        []
+    );
+
+    const activeEvent = events.find((e) => e.id === activeEventId) ?? null;
+
+    return (
+        <ActiveEventContext.Provider
+            value={{ activeEventId, activeEvent, events, setActiveEvent, isLoading }}
+        >
+            {children}
+        </ActiveEventContext.Provider>
+    );
+}
+
+export function useActiveEvent(): ActiveEventContextValue {
+    const context = useContext(ActiveEventContext);
+    if (!context) {
+        throw new Error("useActiveEvent must be used within ActiveEventProvider");
+    }
+    return context;
+}

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -11,26 +11,45 @@ import {
     SidebarMenu,
     SidebarMenuButton,
     SidebarMenuItem,
+    SidebarSeparator,
 } from "@/components/ui/sidebar"
-import { Calendar, Users, Fingerprint, BookOpen, Truck, ShieldAlert, BadgeDollarSign, MessageSquare } from "lucide-react"
+import { Calendar, Users, Fingerprint, BookOpen, Truck, ShieldAlert, BadgeDollarSign, MessageSquare, type LucideIcon } from "lucide-react"
 import { UserButton } from "@/components/user-button"
-import { useLocale } from "next-intl"
+import { EventPicker } from "@/components/event-picker"
+import { useActiveEvent } from "@/components/active-event-context"
+import { useLocale, useTranslations } from "next-intl"
 
-const items = [
-    { title: "Identity & Access", url: "/identity", icon: Fingerprint, requiresSystemAdmin: true },
-    { title: "Event Management", url: "/events", icon: Calendar },
-    { title: "Characters", url: "/characters", icon: Users },
-    { title: "Narrative", url: "/narrative", icon: BookOpen },
-    { title: "Logistics", url: "#", icon: Truck },
-    { title: "NPC & Org Team", url: "#", icon: ShieldAlert },
-    { title: "Finance", url: "#", icon: BadgeDollarSign },
-    { title: "Communications", url: "#", icon: MessageSquare },
+type NavItem = {
+    titleKey: string;
+    url: string;
+    icon: LucideIcon;
+    requiresSystemAdmin?: boolean;
+    eventScoped?: boolean;
+};
+
+const items: NavItem[] = [
+    { titleKey: "sidebar.identity", url: "/identity", icon: Fingerprint, requiresSystemAdmin: true },
+    { titleKey: "sidebar.events", url: "/events", icon: Calendar },
+    { titleKey: "sidebar.characters", url: "/characters", icon: Users, eventScoped: true },
+    { titleKey: "sidebar.narrative", url: "/narrative", icon: BookOpen, eventScoped: true },
+    { titleKey: "sidebar.logistics", url: "#", icon: Truck, eventScoped: true },
+    { titleKey: "sidebar.npcOrg", url: "#", icon: ShieldAlert, eventScoped: true },
+    { titleKey: "sidebar.finance", url: "#", icon: BadgeDollarSign, eventScoped: true },
+    { titleKey: "sidebar.communications", url: "#", icon: MessageSquare, eventScoped: true },
 ]
 
 export function AppSidebar({ isSystemAdmin = false }: { isSystemAdmin?: boolean }) {
     const locale = useLocale();
+    const t = useTranslations("common");
+    const { activeEventId } = useActiveEvent();
 
-    const visibleItems = items.filter(i => !i.requiresSystemAdmin || (i.requiresSystemAdmin && isSystemAdmin));
+    const visibleItems = items.filter(i => !i.requiresSystemAdmin || isSystemAdmin);
+
+    const buildUrl = (item: NavItem) => {
+        if (item.url === "#") return "#";
+        const base = `/${locale}${item.url}`;
+        return item.eventScoped && activeEventId ? `${base}/${activeEventId}` : base;
+    };
 
     return (
         <Sidebar>
@@ -39,29 +58,26 @@ export function AppSidebar({ isSystemAdmin = false }: { isSystemAdmin?: boolean 
             </SidebarHeader>
             <SidebarContent>
                 <SidebarGroup>
-                    <SidebarGroupLabel>Modules</SidebarGroupLabel>
+                    <SidebarGroupLabel>{t("sidebar.modules")}</SidebarGroupLabel>
                     <SidebarGroupContent>
                         <SidebarMenu>
-                            {visibleItems.map((item) => {
-                                const url = item.url.startsWith("/") && item.url !== "/"
-                                    ? `/${locale}${item.url}`
-                                    : item.url;
-                                return (
-                                    <SidebarMenuItem key={item.title}>
-                                        <SidebarMenuButton asChild>
-                                            <a href={url}>
-                                                <item.icon />
-                                                <span>{item.title}</span>
-                                            </a>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
-                                )
-                            })}
+                            {visibleItems.map((item) => (
+                                <SidebarMenuItem key={item.titleKey}>
+                                    <SidebarMenuButton asChild>
+                                        <a href={buildUrl(item)}>
+                                            <item.icon />
+                                            <span>{t(item.titleKey)}</span>
+                                        </a>
+                                    </SidebarMenuButton>
+                                </SidebarMenuItem>
+                            ))}
                         </SidebarMenu>
                     </SidebarGroupContent>
                 </SidebarGroup>
             </SidebarContent>
             <SidebarFooter className="p-4 border-t">
+                <EventPicker />
+                <SidebarSeparator className="my-1" />
                 <UserButton />
             </SidebarFooter>
         </Sidebar>

--- a/frontend/components/characters/characters-list.tsx
+++ b/frontend/components/characters/characters-list.tsx
@@ -34,7 +34,7 @@ import { MoreHorizontal, Search, Plus, Eye, Copy, Lock, Trash2, RotateCcw } from
 import { CharacterListItemDto } from "@/utils/characters-api";
 import { EventDetailDto } from "@/utils/events-api";
 import { CharacterStatusBadge } from "./character-status-badge";
-import { EventSelectorHeader } from "./event-selector-header";
+import { EventContextBanner } from "./event-selector-header";
 import { CreateCharacterDialog } from "./create-character-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import dynamic from "next/dynamic";
@@ -89,7 +89,7 @@ export function CharactersList({ event, initialCharacters, canWrite, token }: Ch
 
     return (
         <div className="space-y-6 lg:max-w-6xl lg:mx-auto">
-            <EventSelectorHeader currentEvent={event} token={token} />
+            <EventContextBanner eventName={event.name} />
 
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div>

--- a/frontend/components/characters/event-selector-header.tsx
+++ b/frontend/components/characters/event-selector-header.tsx
@@ -1,104 +1,14 @@
-"use client";
+import { Calendar } from "lucide-react";
 
-import { useTranslations, useLocale } from "next-intl";
-import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
-import { EventDetailDto, eventsApi } from "@/utils/events-api";
-import { Check, ChevronsUpDown, ArrowLeft } from "lucide-react";
-
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-} from "@/components/ui/command";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
-import Link from "next/link";
-
-interface EventSelectorHeaderProps {
-    currentEvent: EventDetailDto;
-    token: string;
+interface EventContextBannerProps {
+    eventName: string;
 }
 
-export function EventSelectorHeader({ currentEvent, token }: EventSelectorHeaderProps) {
-    const t = useTranslations("characters");
-    const locale = useLocale();
-    const router = useRouter();
-    const [open, setOpen] = useState(false);
-    const [events, setEvents] = useState<any[]>([]);
-
-    useEffect(() => {
-        if (open && events.length === 0) {
-            eventsApi.listEvents(token, { includeArchived: true })
-                .then(setEvents)
-                .catch(console.error);
-        }
-    }, [open, token, events.length]);
-
-    const handleSelect = (eventId: string) => {
-        setOpen(false);
-        if (eventId !== currentEvent.id) {
-            router.push(`/${locale}/characters/${eventId}`);
-        }
-    };
-
+export function EventContextBanner({ eventName }: EventContextBannerProps) {
     return (
-        <div className="flex items-center gap-4 mb-6 pb-6 border-b">
-            <Button variant="ghost" size="icon" asChild className="shrink-0">
-                <Link href={`/${locale}/characters`}>
-                    <ArrowLeft className="h-5 w-5" />
-                </Link>
-            </Button>
-
-            <div className="flex-1">
-                <p className="text-sm font-medium text-muted-foreground mb-1">Event Context</p>
-                <Popover open={open} onOpenChange={setOpen}>
-                    <PopoverTrigger asChild>
-                        <Button
-                            variant="outline"
-                            role="combobox"
-                            aria-expanded={open}
-                            className="w-[300px] justify-between font-semibold"
-                        >
-                            {currentEvent.name}
-                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                        </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[300px] p-0">
-                        <Command>
-                            <CommandInput placeholder={t("fields.placeholders.searchEvent")} />
-                            <CommandList>
-                                <CommandEmpty>No event found.</CommandEmpty>
-                                <CommandGroup>
-                                    {events.map((event) => (
-                                        <CommandItem
-                                            key={event.id}
-                                            value={event.id}
-                                            onSelect={handleSelect}
-                                        >
-                                            <Check
-                                                className={cn(
-                                                    "mr-2 h-4 w-4",
-                                                    currentEvent.id === event.id ? "opacity-100" : "opacity-0"
-                                                )}
-                                            />
-                                            {event.name}
-                                        </CommandItem>
-                                    ))}
-                                </CommandGroup>
-                            </CommandList>
-                        </Command>
-                    </PopoverContent>
-                </Popover>
-            </div>
+        <div className="flex items-center gap-2 mb-6 pb-4 border-b">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">{eventName}</span>
         </div>
     );
 }

--- a/frontend/components/event-picker.tsx
+++ b/frontend/components/event-picker.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Calendar, Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useActiveEvent } from "@/components/active-event-context";
+import {
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    useSidebar,
+} from "@/components/ui/sidebar";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+
+export function EventPicker() {
+    const t = useTranslations("common");
+    const { activeEventId, activeEvent, events, setActiveEvent, isLoading } =
+        useActiveEvent();
+    const { state: sidebarState } = useSidebar();
+    const [open, setOpen] = useState(false);
+
+    const isCollapsed = sidebarState === "collapsed";
+
+    const formatDateRange = (startAt: string, endAt: string) => {
+        const start = new Date(startAt).toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+        });
+        const end = new Date(endAt).toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+        });
+        return `${start} – ${end}`;
+    };
+
+    return (
+        <SidebarMenu>
+            <SidebarMenuItem>
+                <Popover open={open} onOpenChange={setOpen}>
+                    <PopoverTrigger asChild>
+                        <SidebarMenuButton
+                            size="lg"
+                            className="w-full cursor-pointer"
+                            tooltip={t("sidebar.eventPicker.label")}
+                        >
+                            <Calendar className="h-4 w-4 shrink-0" />
+                            {!isCollapsed && (
+                                <>
+                                    <div className="flex flex-col truncate flex-1">
+                                        <span className="text-xs text-muted-foreground leading-none mb-0.5">
+                                            {t("sidebar.eventPicker.label")}
+                                        </span>
+                                        <span className="text-sm font-semibold truncate leading-none">
+                                            {isLoading
+                                                ? "..."
+                                                : activeEvent?.name ??
+                                                  t("sidebar.eventPicker.placeholder")}
+                                        </span>
+                                    </div>
+                                    <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+                                </>
+                            )}
+                        </SidebarMenuButton>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[260px] p-0" side="top" align="start">
+                        <Command>
+                            <CommandInput
+                                placeholder={t("sidebar.eventPicker.searchPlaceholder")}
+                            />
+                            <CommandList>
+                                <CommandEmpty>
+                                    {events.length === 0
+                                        ? t("sidebar.eventPicker.noEvents")
+                                        : t("sidebar.eventPicker.noResults")}
+                                </CommandEmpty>
+                                <CommandGroup>
+                                    {events.map((event) => (
+                                        <CommandItem
+                                            key={event.id}
+                                            value={`${event.name} ${event.id}`}
+                                            onSelect={() => {
+                                                setActiveEvent(
+                                                    event.id === activeEventId ? null : event.id
+                                                );
+                                                setOpen(false);
+                                            }}
+                                        >
+                                            <Check
+                                                className={cn(
+                                                    "mr-2 h-4 w-4 shrink-0",
+                                                    activeEventId === event.id
+                                                        ? "opacity-100"
+                                                        : "opacity-0"
+                                                )}
+                                            />
+                                            <div className="flex flex-col truncate">
+                                                <span className="text-sm truncate">
+                                                    {event.name}
+                                                </span>
+                                                <span className="text-xs text-muted-foreground">
+                                                    {formatDateRange(event.startAt, event.endAt)}
+                                                </span>
+                                            </div>
+                                        </CommandItem>
+                                    ))}
+                                </CommandGroup>
+                            </CommandList>
+                        </Command>
+                    </PopoverContent>
+                </Popover>
+            </SidebarMenuItem>
+        </SidebarMenu>
+    );
+}

--- a/frontend/messages/cs/common.json
+++ b/frontend/messages/cs/common.json
@@ -28,6 +28,24 @@
     "authProvider": "Poskytovatel ověření",
     "lastSignIn": "Poslední přihlášení"
   },
+  "sidebar": {
+    "modules": "Moduly",
+    "identity": "Identita a přístup",
+    "events": "Správa událostí",
+    "characters": "Postavy",
+    "narrative": "Příběh",
+    "logistics": "Logistika",
+    "npcOrg": "NPC a organizační tým",
+    "finance": "Finance",
+    "communications": "Komunikace",
+    "eventPicker": {
+      "label": "Aktivní událost",
+      "placeholder": "Vyberte událost...",
+      "searchPlaceholder": "Hledat události...",
+      "noResults": "Událost nenalezena.",
+      "noEvents": "Žádné dostupné události."
+    }
+  },
   "errors": {
     "unauthorized": "Pro přístup k této stránce musíte být přihlášeni.",
     "forbidden": "Nemáte oprávnění k prohlížení tohoto obsahu.",

--- a/frontend/messages/en/common.json
+++ b/frontend/messages/en/common.json
@@ -28,6 +28,24 @@
     "authProvider": "Authentication Provider",
     "lastSignIn": "Last Sign In"
   },
+  "sidebar": {
+    "modules": "Modules",
+    "identity": "Identity & Access",
+    "events": "Event Management",
+    "characters": "Characters",
+    "narrative": "Narrative",
+    "logistics": "Logistics",
+    "npcOrg": "NPC & Org Team",
+    "finance": "Finance",
+    "communications": "Communications",
+    "eventPicker": {
+      "label": "Active Event",
+      "placeholder": "Select an event...",
+      "searchPlaceholder": "Search events...",
+      "noResults": "No event found.",
+      "noEvents": "No events available."
+    }
+  },
   "errors": {
     "unauthorized": "You must be logged in to access this page.",
     "forbidden": "You do not have permission to view this content.",

--- a/frontend/utils/active-event-cookie.ts
+++ b/frontend/utils/active-event-cookie.ts
@@ -1,0 +1,19 @@
+export const ACTIVE_EVENT_COOKIE_NAME = "sancho_active_event";
+export const ACTIVE_EVENT_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+export function getActiveEventIdFromCookie(cookieString: string): string | null {
+    const match = cookieString
+        .split("; ")
+        .find((row) => row.startsWith(`${ACTIVE_EVENT_COOKIE_NAME}=`));
+    if (!match) return null;
+    const value = match.split("=")[1];
+    return value || null;
+}
+
+export function setActiveEventCookie(eventId: string): void {
+    document.cookie = `${ACTIVE_EVENT_COOKIE_NAME}=${eventId}; path=/; max-age=${ACTIVE_EVENT_COOKIE_MAX_AGE}; SameSite=Lax`;
+}
+
+export function clearActiveEventCookie(): void {
+    document.cookie = `${ACTIVE_EVENT_COOKIE_NAME}=; path=/; max-age=0`;
+}


### PR DESCRIPTION
## Changes

### New Components & Context
- Added `ActiveEventProvider` context to manage global event state across the app
- Created `EventPicker` component in sidebar footer for centralized event selection
- Replaced scattered event selectors with context-driven approach

### Updated Pages
- Modified `/characters` and `/narrative` landing pages to redirect to event-scoped routes when an active event is set via cookie
- Integrated `ActiveEventProvider` in app layout

### Sidebar Improvements
- Added i18n support for navigation labels (titles now use translation keys)
- Event-scoped menu items now automatically append `eventId` to URLs when an active event is selected
- `EventPicker` displays in sidebar footer with date ranges
- Simplified `EventContextBanner` to show only event name

### Utilities & Persistence
- Added `active-event-cookie.ts` utility for managing `sancho_active_event` cookie (30-day expiration)
- Cookie persists user's event selection across sessions

### Localization
- Added Czech and English translations for sidebar labels and event picker

## Benefits
- Single source of truth for active event selection
- Automatic URL-based event scoping for relevant pages
- Improved UX with persistent event selection
- Better i18n support throughout the app