### PR TITLE
feat(narrative): add faction sigil upload, replace, and delete

### DIFF
--- a/backend/Sancho.API/Program.cs
+++ b/backend/Sancho.API/Program.cs
@@ -95,6 +95,7 @@ builder.Services.AddScoped<CharacterAuthorizationService>();
 builder.Services.AddScoped<CharacterStorageService>();
 builder.Services.AddScoped<NarrativeAuthorizationService>();
 builder.Services.AddScoped<NarrativeDocumentLinkService>();
+builder.Services.AddHttpClient<NarrativeStorageService>();
 builder.Services.AddScoped<ICharacterNarrativeService, NarrativeCharacterNarrativeService>();
 
 builder.Services.AddHttpClient();

--- a/backend/Sancho.Modules/Narrative/NarrativeEndpoints.cs
+++ b/backend/Sancho.Modules/Narrative/NarrativeEndpoints.cs
@@ -75,6 +75,10 @@ public static class NarrativeEndpoints
         group.MapPost("/factions/{factionId:guid}/documents/google-drive", AddFactionGoogleDriveDocument);
         group.MapDelete("/factions/{factionId:guid}/documents/{documentId:guid}", DeleteFactionDocument);
 
+        group.MapPost("/factions/{factionId:guid}/sigil/upload-url", CreateSigilUploadUrl);
+        group.MapPost("/factions/{factionId:guid}/sigil/confirm", ConfirmSigil);
+        group.MapDelete("/factions/{factionId:guid}/sigil", RemoveSigil);
+
         group.MapGet("/items", ListItems);
         group.MapPost("/items", CreateItem);
         group.MapGet("/items/{itemId:guid}", GetItemById);
@@ -1094,6 +1098,59 @@ public static class NarrativeEndpoints
         req.Content = JsonContent.Create(new { deleted_at = (DateTimeOffset?)null, deleted_by = (Guid?)null, deletion_reason = (string?)null });
         var resp = await httpClient.SendAsync(req);
         return resp.IsSuccessStatusCode ? Results.NoContent() : Results.Problem($"Failed to undelete faction: {resp.StatusCode}");
+    }
+
+    private static async Task<IResult> CreateSigilUploadUrl(Guid eventId, Guid factionId, ClaimsPrincipal user, [FromBody] NarrativeUploadUrlRequest request, IConfiguration config, HttpClient httpClient, NarrativeAuthorizationService authz, NarrativeStorageService storage)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+
+        var faction = await GetFaction(eventId, factionId, url!, key!, httpClient, includeDeleted: false);
+        if (faction is null) return Results.NotFound();
+        if (faction.status == NarrativeStatuses.Locked) return Results.BadRequest("Locked faction sigil is read-only.");
+
+        try { return Results.Ok(await storage.CreateSigilUploadUrlAsync(url!, key!, eventId, factionId, request)); }
+        catch (InvalidOperationException ex) { return Results.BadRequest(ex.Message); }
+    }
+
+    private static async Task<IResult> ConfirmSigil(Guid eventId, Guid factionId, ClaimsPrincipal user, [FromBody] ConfirmSigilRequest request, IConfiguration config, HttpClient httpClient, NarrativeAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+
+        var faction = await GetFaction(eventId, factionId, url!, key!, httpClient, includeDeleted: false);
+        if (faction is null) return Results.NotFound();
+        if (faction.status == NarrativeStatuses.Locked) return Results.BadRequest("Locked faction sigil is read-only.");
+
+        var req = new HttpRequestMessage(HttpMethod.Patch, $"{url}/rest/v1/narrative_factions?id=eq.{factionId}&event_id=eq.{eventId}");
+        req.Headers.Add("Prefer", "return=representation");
+        AddHeaders(req, key!);
+        req.Content = JsonContent.Create(new { sigil_url = request.FilePath, updated_at = DateTimeOffset.UtcNow });
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return Results.Problem($"Failed to confirm sigil: {resp.StatusCode}");
+        var updated = (await resp.Content.ReadFromJsonAsync<List<SupabaseNarrativeFactionRow>>())?.FirstOrDefault();
+        return updated is null ? Results.Problem("Sigil confirmed but payload missing.") : Results.Ok(ToFactionDto(updated, access.CanWrite));
+    }
+
+    private static async Task<IResult> RemoveSigil(Guid eventId, Guid factionId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, NarrativeAuthorizationService authz, NarrativeStorageService storage)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+
+        var faction = await GetFaction(eventId, factionId, url!, key!, httpClient, includeDeleted: false);
+        if (faction is null) return Results.NotFound();
+        if (faction.status == NarrativeStatuses.Locked) return Results.BadRequest("Locked faction sigil is read-only.");
+
+        if (!string.IsNullOrWhiteSpace(faction.sigil_url)) await storage.DeleteObjectAsync(url!, key!, faction.sigil_url);
+
+        var req = new HttpRequestMessage(HttpMethod.Patch, $"{url}/rest/v1/narrative_factions?id=eq.{factionId}&event_id=eq.{eventId}");
+        AddHeaders(req, key!);
+        req.Content = JsonContent.Create(new { sigil_url = (string?)null });
+        var resp = await httpClient.SendAsync(req);
+        return resp.IsSuccessStatusCode ? Results.NoContent() : Results.Problem($"Failed to remove sigil: {resp.StatusCode}");
     }
 
     private static async Task<IResult> ListFactionMembers(Guid eventId, Guid factionId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, NarrativeAuthorizationService authz)

--- a/backend/Sancho.Modules/Narrative/NarrativeModels.cs
+++ b/backend/Sancho.Modules/Narrative/NarrativeModels.cs
@@ -684,6 +684,25 @@ internal record SupabaseNarrativePlotItemRow(
     [property: JsonPropertyName("created_at")] DateTimeOffset created_at
 );
 
+public record NarrativeUploadUrlRequest(
+    string FileName,
+    string ContentType,
+    long SizeBytes
+);
+
+public record SigilUploadUrlResponse(
+    string UploadUrl,
+    string FilePath
+);
+
+public record ConfirmSigilRequest(
+    string FilePath
+);
+
+internal record SupabaseNarrativeSignUploadResponse(
+    string token
+);
+
 internal record SupabaseNarrativePermissionRow(
     string permission
 );

--- a/backend/Sancho.Modules/Narrative/NarrativeStorageService.cs
+++ b/backend/Sancho.Modules/Narrative/NarrativeStorageService.cs
@@ -1,0 +1,127 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Narrative.Models;
+
+namespace Narrative.Services;
+
+public sealed class NarrativeStorageService
+{
+    private const long MaxUploadBytes = 10L * 1024L * 1024L;
+    private const string BucketName = "narrative";
+
+    private static readonly HashSet<string> AllowedImageMimeTypes =
+    [
+        "image/jpeg",
+        "image/png",
+        "image/webp"
+    ];
+
+    private static readonly Dictionary<string, HashSet<string>> ExtensionMimeMap = new()
+    {
+        { ".jpg",  ["image/jpeg"] },
+        { ".jpeg", ["image/jpeg"] },
+        { ".png",  ["image/png"] },
+        { ".webp", ["image/webp"] }
+    };
+
+    private readonly HttpClient _httpClient;
+
+    public NarrativeStorageService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<SigilUploadUrlResponse> CreateSigilUploadUrlAsync(
+        string supabaseUrl,
+        string supabaseKey,
+        Guid eventId,
+        Guid factionId,
+        NarrativeUploadUrlRequest request)
+    {
+        ValidateUpload(request);
+        var extension = NormalizeExtension(request.FileName, request.ContentType);
+        var filePath = $"{eventId}/{factionId}/sigil/sigil.{extension}";
+        var uploadUrl = await CreateSignedUploadUrlAsync(supabaseUrl, supabaseKey, filePath);
+        return new SigilUploadUrlResponse(uploadUrl, filePath);
+    }
+
+    public async Task DeleteObjectAsync(string supabaseUrl, string supabaseKey, string filePath)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"{supabaseUrl}/storage/v1/object/{BucketName}/{EncodeStoragePath(filePath)}");
+        AddSupabaseHeaders(request, supabaseKey);
+        await _httpClient.SendAsync(request);
+    }
+
+    private async Task<string> CreateSignedUploadUrlAsync(string supabaseUrl, string supabaseKey, string filePath)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{supabaseUrl}/storage/v1/object/upload/sign/{BucketName}/{EncodeStoragePath(filePath)}");
+        AddSupabaseHeaders(request, supabaseKey);
+        request.Content = JsonContent.Create(new { expiresIn = 600, upsert = true });
+        var response = await _httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException("Failed to generate signed upload URL.");
+        }
+
+        var signResult = await response.Content.ReadFromJsonAsync<SupabaseNarrativeSignUploadResponse>();
+        if (string.IsNullOrWhiteSpace(signResult?.token))
+        {
+            throw new InvalidOperationException("Failed to parse upload token.");
+        }
+
+        return $"{supabaseUrl}/storage/v1/object/upload/sign/{BucketName}/{EncodeStoragePath(filePath)}?token={signResult.token}";
+    }
+
+    private static void ValidateUpload(NarrativeUploadUrlRequest request)
+    {
+        if (request.SizeBytes <= 0 || request.SizeBytes > MaxUploadBytes)
+        {
+            throw new InvalidOperationException($"File size must be between 1 byte and {MaxUploadBytes / (1024 * 1024)} MB.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ContentType) || !AllowedImageMimeTypes.Contains(request.ContentType.ToLowerInvariant()))
+        {
+            throw new InvalidOperationException("Unsupported content type.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.FileName))
+        {
+            throw new InvalidOperationException("File name is required.");
+        }
+
+        var extension = Path.GetExtension(request.FileName).ToLowerInvariant();
+        if (!string.IsNullOrWhiteSpace(extension) && ExtensionMimeMap.TryGetValue(extension, out var expectedMimes))
+        {
+            if (!expectedMimes.Contains(request.ContentType.ToLowerInvariant()))
+            {
+                throw new InvalidOperationException($"File extension '{extension}' does not match the declared content type '{request.ContentType}'.");
+            }
+        }
+    }
+
+    private static string NormalizeExtension(string fileName, string contentType)
+    {
+        var ext = Path.GetExtension(fileName).Trim('.').ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(ext))
+        {
+            return contentType switch
+            {
+                "image/jpeg" => "jpg",
+                "image/png" => "png",
+                "image/webp" => "webp",
+                _ => "bin"
+            };
+        }
+
+        return ext == "jpeg" ? "jpg" : ext;
+    }
+
+    private static string EncodeStoragePath(string path) =>
+        string.Join('/', path.TrimStart('/').Split('/').Select(Uri.EscapeDataString));
+
+    private static void AddSupabaseHeaders(HttpRequestMessage request, string key)
+    {
+        request.Headers.Add("apikey", key);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+    }
+}

--- a/frontend/components/narrative/faction-detail.tsx
+++ b/frontend/components/narrative/faction-detail.tsx
@@ -35,6 +35,7 @@ import { FactionRelationshipsPanel } from "./faction-relationships-panel";
 import { FactionLinksPanel } from "./faction-links-panel";
 import { FactionDocumentsPanel } from "./faction-documents-panel";
 import { EditFactionNameDialog } from "./edit-faction-name-dialog";
+import { SigilUpload } from "./sigil-upload";
 
 interface FactionDetailProps {
     event: EventDetailDto;
@@ -126,17 +127,15 @@ export function FactionDetail({
                     </div>
                 )}
 
-                {/* Avatar section (Avatar exists for factions, not for quests) */}
-                <div className="flex-shrink-0 mt-2 md:mt-0 relative group">
-                    {faction.sigilUrl ? (
-                        <div className="h-24 w-24 rounded-lg bg-muted border overflow-hidden">
-                            <img src={faction.sigilUrl} alt="sigil" className="h-full w-full object-cover" />
-                        </div>
-                    ) : (
-                        <div className="h-24 w-24 rounded-lg bg-muted flex items-center justify-center text-xs text-muted-foreground border border-dashed text-center p-2">
-                            {t("factions.sigil.noSigil")}
-                        </div>
-                    )}
+                {/* Faction sigil (round avatar with upload support) */}
+                <div className="flex-shrink-0 mt-2 md:mt-0">
+                    <SigilUpload
+                        eventId={event.id}
+                        faction={faction}
+                        token={token}
+                        canWrite={canWrite}
+                        onSigilChanged={(url) => setFaction(f => ({ ...f, sigilUrl: url }))}
+                    />
                 </div>
 
                 <div className="flex-1 min-w-0 flex flex-col justify-between">

--- a/frontend/components/narrative/sigil-upload.tsx
+++ b/frontend/components/narrative/sigil-upload.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { Camera, Trash2, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { NarrativeFactionDto, narrativeApi } from "@/utils/narrative-api";
+import { resizeImageIfNeeded } from "@/utils/image-resize";
+
+const MAX_SIGIL_BYTES = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+interface SigilUploadProps {
+    eventId: string;
+    faction: NarrativeFactionDto;
+    token: string;
+    canWrite: boolean;
+    onSigilChanged?: (newSigilUrl: string | null) => void;
+}
+
+export function SigilUpload({ eventId, faction, token, canWrite, onSigilChanged }: SigilUploadProps) {
+    const router = useRouter();
+    const t = useTranslations("narrative.factions.sigil");
+    const canEdit = canWrite && faction.status !== "Locked" && !faction.deletedAt;
+
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        if (!ALLOWED_TYPES.includes(file.type)) {
+            toast.error(t("invalidType"));
+            return;
+        }
+
+        try {
+            setIsUploading(true);
+
+            // Auto-resize if needed
+            let processedFile = file;
+            if (file.size > MAX_SIGIL_BYTES) {
+                toast.info(t("resizing"));
+                processedFile = await resizeImageIfNeeded(file, MAX_SIGIL_BYTES);
+            }
+
+            // 1. Get signed upload URL
+            const { uploadUrl, filePath } = await narrativeApi.createSigilUploadUrl(token, eventId, faction.id, {
+                fileName: processedFile.name,
+                contentType: processedFile.type,
+                sizeBytes: processedFile.size,
+            });
+
+            // 2. Upload direct to Supabase Storage
+            const uploadResponse = await fetch(uploadUrl, {
+                method: "PUT",
+                body: processedFile,
+                headers: { "Content-Type": processedFile.type },
+            });
+
+            if (!uploadResponse.ok) {
+                throw new Error("Failed to upload image to storage");
+            }
+
+            // 3. Confirm with backend
+            const updated = await narrativeApi.confirmSigil(token, eventId, faction.id, { filePath });
+
+            toast.success(t("uploadSuccess"));
+            onSigilChanged?.(updated.sigilUrl);
+            router.refresh();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("uploadFailed"));
+        } finally {
+            setIsUploading(false);
+            if (fileInputRef.current) {
+                fileInputRef.current.value = "";
+            }
+        }
+    };
+
+    const handleRemove = async () => {
+        if (!confirm(t("removeConfirm"))) return;
+
+        try {
+            await narrativeApi.removeSigil(token, eventId, faction.id);
+            toast.success(t("removeSuccess"));
+            onSigilChanged?.(null);
+            router.refresh();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("removeFailed"));
+        }
+    };
+
+    return (
+        <div className="relative group">
+            <Avatar className="h-24 w-24 border-4 border-background shadow-sm">
+                <AvatarImage src={faction.sigilUrl || ""} alt={faction.name} className="object-cover" />
+                <AvatarFallback className="bg-primary/10 text-primary text-2xl uppercase">
+                    {faction.name.slice(0, 2)}
+                </AvatarFallback>
+            </Avatar>
+
+            {canEdit && (
+                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/40 rounded-full transition-opacity">
+                    <input
+                        type="file"
+                        ref={fileInputRef}
+                        className="hidden"
+                        accept="image/jpeg,image/png,image/webp"
+                        onChange={handleFileChange}
+                    />
+
+                    {isUploading ? (
+                        <Loader2 className="text-white h-8 w-8 animate-spin" />
+                    ) : (
+                        <div className="flex gap-2">
+                            <Button
+                                size="icon"
+                                variant="secondary"
+                                className="h-10 w-10 rounded-full bg-white/90 hover:bg-white text-black"
+                                onClick={() => fileInputRef.current?.click()}
+                                title={t("uploadTitle")}
+                            >
+                                <Camera className="h-5 w-5" />
+                            </Button>
+
+                            {faction.sigilUrl && (
+                                <Button
+                                    size="icon"
+                                    variant="destructive"
+                                    className="h-10 w-10 rounded-full"
+                                    onClick={handleRemove}
+                                    title={t("removeTitle")}
+                                >
+                                    <Trash2 className="h-5 w-5" />
+                                </Button>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/messages/cs/narrative.json
+++ b/frontend/messages/cs/narrative.json
@@ -316,7 +316,16 @@
             "rolePlaceholder": "např. Vůdce, Průzkumník..."
         },
         "sigil": {
-            "noSigil": "Bez znaku"
+            "noSigil": "Bez znaku",
+            "uploadSuccess": "Znak byl úspěšně nahrán",
+            "uploadFailed": "Nahrání znaku selhalo",
+            "removeConfirm": "Opravdu chcete odstranit tento znak?",
+            "removeSuccess": "Znak byl odstraněn",
+            "removeFailed": "Odstranění znaku selhalo",
+            "uploadTitle": "Nahrát nový znak",
+            "removeTitle": "Odstranit znak",
+            "resizing": "Zmenšování obrázku na limit 10 MB...",
+            "invalidType": "Obrázek musí být ve formátu JPG, PNG nebo WebP"
         },
         "relationships": {
             "title": "Vztahy",

--- a/frontend/messages/en/narrative.json
+++ b/frontend/messages/en/narrative.json
@@ -321,7 +321,16 @@
             "rolePlaceholder": "e.g. Leader, Scout..."
         },
         "sigil": {
-            "noSigil": "No Sigil"
+            "noSigil": "No Sigil",
+            "uploadSuccess": "Sigil uploaded successfully",
+            "uploadFailed": "Failed to upload sigil",
+            "removeConfirm": "Are you sure you want to remove this sigil?",
+            "removeSuccess": "Sigil removed",
+            "removeFailed": "Failed to remove sigil",
+            "uploadTitle": "Upload new sigil",
+            "removeTitle": "Remove sigil",
+            "resizing": "Resizing image to fit 10 MB limit...",
+            "invalidType": "Image must be JPG, PNG, or WebP"
         },
         "relationships": {
             "title": "Relationships",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.10.1",
+  "version": "0.15.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.10.1",
+      "version": "0.15.27",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/utils/image-resize.ts
+++ b/frontend/utils/image-resize.ts
@@ -1,0 +1,79 @@
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Resizes an image file if it exceeds the maximum byte size.
+ * Uses the Canvas API to scale dimensions and reduce quality iteratively.
+ * Returns the original file unchanged if it's already within the limit.
+ */
+export async function resizeImageIfNeeded(
+    file: File,
+    maxBytes: number = DEFAULT_MAX_BYTES
+): Promise<File> {
+    if (file.size <= maxBytes) return file;
+
+    const img = await loadImage(file);
+    const mimeType = file.type as "image/jpeg" | "image/png" | "image/webp";
+
+    // Start with a scale factor based on size ratio, then iterate quality
+    let scaleFactor = Math.sqrt(maxBytes / file.size) * 0.95; // slight extra margin
+    const qualities = [0.85, 0.7, 0.5, 0.3];
+
+    for (const quality of qualities) {
+        const width = Math.round(img.width * scaleFactor);
+        const height = Math.round(img.height * scaleFactor);
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext("2d");
+        if (!ctx) throw new Error("Failed to get canvas context");
+        ctx.drawImage(img, 0, 0, width, height);
+
+        const blob = await canvasToBlob(canvas, mimeType, quality);
+        if (blob.size <= maxBytes) {
+            return new File([blob], file.name, { type: mimeType });
+        }
+
+        // Shrink further for next iteration
+        scaleFactor *= 0.8;
+    }
+
+    // Final fallback: aggressive downscale with lowest quality
+    const width = Math.round(img.width * 0.3);
+    const height = Math.round(img.height * 0.3);
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Failed to get canvas context");
+    ctx.drawImage(img, 0, 0, width, height);
+    const blob = await canvasToBlob(canvas, mimeType, 0.3);
+    return new File([blob], file.name, { type: mimeType });
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        const url = URL.createObjectURL(file);
+        img.onload = () => {
+            URL.revokeObjectURL(url);
+            resolve(img);
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(url);
+            reject(new Error("Failed to load image"));
+        };
+        img.src = url;
+    });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+        canvas.toBlob(
+            (blob) => (blob ? resolve(blob) : reject(new Error("Canvas toBlob failed"))),
+            type,
+            quality
+        );
+    });
+}

--- a/frontend/utils/narrative-api.ts
+++ b/frontend/utils/narrative-api.ts
@@ -77,6 +77,17 @@ export interface NarrativeDocumentLinkDto {
     createdAt: string;
 }
 
+export interface NarrativeUploadUrlRequest {
+    fileName: string;
+    contentType: string;
+    sizeBytes: number;
+}
+
+export interface NarrativeFileUploadUrlResponse {
+    uploadUrl: string;
+    filePath: string;
+}
+
 export interface NarrativeFactionDto {
     id: string;
     eventId: string;
@@ -846,6 +857,26 @@ export const narrativeApi = {
             headers: { Authorization: `Bearer ${token}` },
         }),
 
+    // Faction Sigil
+    createSigilUploadUrl: (token: string, eventId: string, factionId: string, data: NarrativeUploadUrlRequest) =>
+        fetcher<NarrativeFileUploadUrlResponse>(`/api/events/${eventId}/narrative/factions/${factionId}/sigil/upload-url`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        }),
+
+    confirmSigil: (token: string, eventId: string, factionId: string, data: { filePath: string }) =>
+        fetcher<NarrativeFactionDto>(`/api/events/${eventId}/narrative/factions/${factionId}/sigil/confirm`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        }),
+
+    removeSigil: (token: string, eventId: string, factionId: string) =>
+        fetcher<void>(`/api/events/${eventId}/narrative/factions/${factionId}/sigil`, {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${token}` },
+        }),
 
     // Items
     listItems: (token: string, eventId: string, includeDeleted: boolean = false) =>

--- a/supabase/migrations/20260315150000_create_narrative_bucket.sql
+++ b/supabase/migrations/20260315150000_create_narrative_bucket.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- Migration: Create Narrative Storage Bucket
+-- Ensures the 'narrative' bucket exists for faction sigils
+-- and future narrative-context image uploads.
+-- ============================================================
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'narrative',
+  'narrative',
+  false,
+  10485760, -- 10MB
+  ARRAY[
+    'image/jpeg',
+    'image/png',
+    'image/webp'
+  ]::text[]
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- The backend uses the service role key for storage operations, so RLS on bucket objects
+-- is bypassed by the backend API. No additional storage RLS policies needed.


### PR DESCRIPTION
## Changes

### Backend
- Added `NarrativeStorageService` for Supabase Storage integration with signed upload URLs
- Implemented three new endpoints for faction sigil management:
  - `POST /factions/{id}/sigil/upload-url` - Get signed upload URL
  - `POST /factions/{id}/sigil/confirm` - Confirm sigil after upload
  - `DELETE /factions/{id}/sigil` - Remove sigil
- Added validation for image uploads (JPEG, PNG, WebP, max 10MB)
- Created Supabase migration to set up `narrative` storage bucket

### Frontend
- New `SigilUpload` component with hover UI for upload/delete actions
- Added `image-resize.ts` utility for client-side image optimization before upload
- Added `createSigilUploadUrl`, `confirmSigil`, and `removeSigil` API methods
- Updated `faction-detail.tsx` to use new `SigilUpload` component
- Added i18n translations for upload success/failure messages (EN, CS)

### Features
- Direct upload to Supabase Storage via signed URLs
- Automatic image resizing if file exceeds 10MB limit
- Confirmation flow: get URL → upload → confirm with backend
- Ability to replace and delete faction sigils
- Read-only enforcement for locked factions
- Avatar-style UI with fallback initials