### PR TITLE
feat(characters): add relationship & item management

### DIFF
--- a/backend/Sancho.Modules/Character/CharacterEndpoints.cs
+++ b/backend/Sancho.Modules/Character/CharacterEndpoints.cs
@@ -43,6 +43,15 @@ public static class CharacterEndpoints
         group.MapDelete("/{characterId:guid}/photo", RemovePhoto);
 
         group.MapGet("/{characterId:guid}/narrative-links", GetNarrativeLinks);
+
+        group.MapGet("/{characterId:guid}/relationships", ListCharacterRelationships);
+        group.MapPost("/{characterId:guid}/relationships", CreateCharacterRelationship);
+        group.MapPatch("/{characterId:guid}/relationships/{relationshipId:guid}", UpdateCharacterRelationship);
+        group.MapDelete("/{characterId:guid}/relationships/{relationshipId:guid}", DeleteCharacterRelationship);
+
+        group.MapGet("/{characterId:guid}/items", ListCharacterItems);
+        group.MapPut("/{characterId:guid}/items/{itemId:guid}", AssignItemToCharacter);
+        group.MapDelete("/{characterId:guid}/items/{itemId:guid}", RemoveItemFromCharacter);
     }
 
     private static async Task<IResult> ListCharacters(Guid eventId, ClaimsPrincipal user, [FromQuery] bool includeDeleted, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
@@ -552,8 +561,9 @@ public static class CharacterEndpoints
         var factionsTask = narrativeService.GetFactionsAsync(eventId, characterId);
         var relationshipsTask = narrativeService.GetRelationshipsAsync(eventId, characterId);
         var questsTask = narrativeService.GetQuestsAsync(eventId, characterId);
-        await Task.WhenAll(factionsTask, relationshipsTask, questsTask);
-        return Results.Ok(new CharacterNarrativeLinksDto(factionsTask.Result, relationshipsTask.Result, questsTask.Result));
+        var itemsTask = GetAssignedItemsAsync(eventId, characterId, url!, key!, httpClient);
+        await Task.WhenAll(factionsTask, relationshipsTask, questsTask, itemsTask);
+        return Results.Ok(new CharacterNarrativeLinksDto(factionsTask.Result, relationshipsTask.Result, questsTask.Result, itemsTask.Result));
     }
 
     private static CharacterDetailDto ToDetail(SupabaseCharacterRow row, bool canReadInternal) =>
@@ -647,5 +657,264 @@ public static class CharacterEndpoints
 
         error = null;
         return true;
+    }
+
+    // ─── Character Relationships ────────────────────────────────────────
+
+    private static async Task<IResult> ListCharacterRelationships(Guid eventId, Guid characterId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanRead) return Results.Forbid();
+        if (!await CharacterExists(eventId, characterId, url!, key!, httpClient, includeDeleted: false)) return Results.NotFound();
+
+        var query = $"{url}/rest/v1/character_relationships" +
+                    $"?event_id=eq.{eventId}" +
+                    $"&or=(source_character_id.eq.{characterId},target_character_id.eq.{characterId})" +
+                    "&select=id,event_id,source_character_id,target_character_id,relation_type,relation_mode,mirror_group_id,is_auto_mirror,is_active,description,created_at,updated_at" +
+                    "&order=created_at.desc";
+        var req = new HttpRequestMessage(HttpMethod.Get, query);
+        AddHeaders(req, key!);
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return Results.Problem($"Failed to list character relationships: {resp.StatusCode}");
+        var rows = await resp.Content.ReadFromJsonAsync<List<SupabaseCharacterRelationshipRow>>() ?? [];
+
+        // Resolve target character names
+        var characterIds = rows.SelectMany(r => new[] { r.source_character_id, r.target_character_id }).Distinct().ToList();
+        var nameMap = await GetCharacterNames(characterIds, url!, key!, httpClient);
+
+        var dtos = rows.Select(r =>
+        {
+            var targetId = r.source_character_id == characterId ? r.target_character_id : r.source_character_id;
+            var targetName = nameMap.GetValueOrDefault(targetId, "Unknown");
+            return new CharacterRelationshipDto(r.id, r.event_id, r.source_character_id, r.target_character_id, targetName, r.relation_type, r.relation_mode, r.mirror_group_id, r.is_auto_mirror, r.description, r.created_at, r.updated_at);
+        });
+        return Results.Ok(dtos);
+    }
+
+    private static async Task<IResult> CreateCharacterRelationship(Guid eventId, Guid characterId, ClaimsPrincipal user, [FromBody] CreateCharacterRelationshipRequest request, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+        if (!await CharacterExists(eventId, characterId, url!, key!, httpClient, includeDeleted: false)) return Results.NotFound();
+
+        if (string.IsNullOrWhiteSpace(request.RelationType)) return Results.BadRequest("Relation type is required.");
+        if (request.RelationType.Length > 100) return Results.BadRequest("Relation type cannot be longer than 100 characters.");
+        if (!IsValidRelationshipMode(request.RelationMode)) return Results.BadRequest("Relation mode must be 'directional' or 'auto_mirrored'.");
+        if (request.TargetCharacterId == characterId) return Results.BadRequest("Character cannot reference itself.");
+        if (!await CharacterExists(eventId, request.TargetCharacterId, url!, key!, httpClient, includeDeleted: false))
+            return Results.BadRequest("Target character not found in event.");
+
+        var mirrorGroupId = IsAutoMirrored(request.RelationMode) ? Guid.NewGuid() : (Guid?)null;
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"{url}/rest/v1/character_relationships");
+        req.Headers.Add("Prefer", "return=representation");
+        AddHeaders(req, key!);
+        req.Content = JsonContent.Create(new
+        {
+            event_id = eventId,
+            source_character_id = characterId,
+            target_character_id = request.TargetCharacterId,
+            relation_type = request.RelationType.Trim(),
+            relation_mode = request.RelationMode,
+            mirror_group_id = mirrorGroupId,
+            is_auto_mirror = false,
+            description = request.Description
+        });
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return Results.Problem($"Failed to create character relationship: {resp.StatusCode}");
+        var created = (await resp.Content.ReadFromJsonAsync<List<SupabaseCharacterRelationshipRow>>())?.FirstOrDefault();
+        if (created is null) return Results.Problem("Relationship created but payload missing.");
+
+        if (IsAutoMirrored(request.RelationMode))
+        {
+            var mirrorReq = new HttpRequestMessage(HttpMethod.Post, $"{url}/rest/v1/character_relationships");
+            mirrorReq.Headers.Add("Prefer", "return=minimal");
+            AddHeaders(mirrorReq, key!);
+            mirrorReq.Content = JsonContent.Create(new
+            {
+                event_id = eventId,
+                source_character_id = request.TargetCharacterId,
+                target_character_id = characterId,
+                relation_type = request.RelationType.Trim(),
+                relation_mode = request.RelationMode,
+                mirror_group_id = mirrorGroupId,
+                is_auto_mirror = true,
+                description = request.Description
+            });
+            await httpClient.SendAsync(mirrorReq);
+        }
+
+        var nameMap = await GetCharacterNames([characterId, request.TargetCharacterId], url!, key!, httpClient);
+        var targetName = nameMap.GetValueOrDefault(request.TargetCharacterId, "Unknown");
+        return Results.Created(
+            $"/api/events/{eventId}/characters/{characterId}/relationships/{created.id}",
+            new CharacterRelationshipDto(created.id, created.event_id, created.source_character_id, created.target_character_id, targetName, created.relation_type, created.relation_mode, created.mirror_group_id, created.is_auto_mirror, created.description, created.created_at, created.updated_at));
+    }
+
+    private static async Task<IResult> UpdateCharacterRelationship(Guid eventId, Guid characterId, Guid relationshipId, ClaimsPrincipal user, [FromBody] UpdateCharacterRelationshipRequest request, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+        var current = await GetCharacterRelationship(eventId, characterId, relationshipId, url!, key!, httpClient);
+        if (current is null) return Results.NotFound();
+
+        var nextType = request.RelationType?.Trim() ?? current.relation_type;
+        if (nextType.Length > 100) return Results.BadRequest("Relation type cannot be longer than 100 characters.");
+        var nextDescription = request.Description ?? current.description;
+
+        var req = new HttpRequestMessage(HttpMethod.Patch, $"{url}/rest/v1/character_relationships?id=eq.{relationshipId}&event_id=eq.{eventId}");
+        req.Headers.Add("Prefer", "return=representation");
+        AddHeaders(req, key!);
+        req.Content = JsonContent.Create(new
+        {
+            relation_type = nextType,
+            description = nextDescription
+        });
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return Results.Problem($"Failed to update character relationship: {resp.StatusCode}");
+        var updated = (await resp.Content.ReadFromJsonAsync<List<SupabaseCharacterRelationshipRow>>())?.FirstOrDefault();
+        if (updated is null) return Results.Problem("Relationship update payload missing.");
+
+        if (updated.mirror_group_id.HasValue && !updated.is_auto_mirror)
+        {
+            var mirrorPatch = new HttpRequestMessage(HttpMethod.Patch, $"{url}/rest/v1/character_relationships?mirror_group_id=eq.{updated.mirror_group_id.Value}&is_auto_mirror=eq.true&event_id=eq.{eventId}");
+            AddHeaders(mirrorPatch, key!);
+            mirrorPatch.Content = JsonContent.Create(new
+            {
+                relation_type = nextType,
+                description = nextDescription
+            });
+            await httpClient.SendAsync(mirrorPatch);
+        }
+
+        var nameMap = await GetCharacterNames([updated.source_character_id, updated.target_character_id], url!, key!, httpClient);
+        var targetId = updated.source_character_id == characterId ? updated.target_character_id : updated.source_character_id;
+        return Results.Ok(new CharacterRelationshipDto(updated.id, updated.event_id, updated.source_character_id, updated.target_character_id, nameMap.GetValueOrDefault(targetId, "Unknown"), updated.relation_type, updated.relation_mode, updated.mirror_group_id, updated.is_auto_mirror, updated.description, updated.created_at, updated.updated_at));
+    }
+
+    private static async Task<IResult> DeleteCharacterRelationship(Guid eventId, Guid characterId, Guid relationshipId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+        var current = await GetCharacterRelationship(eventId, characterId, relationshipId, url!, key!, httpClient);
+        if (current is null) return Results.NotFound();
+
+        HttpRequestMessage req;
+        if (current.mirror_group_id.HasValue)
+        {
+            req = new HttpRequestMessage(HttpMethod.Delete, $"{url}/rest/v1/character_relationships?event_id=eq.{eventId}&mirror_group_id=eq.{current.mirror_group_id.Value}");
+        }
+        else
+        {
+            req = new HttpRequestMessage(HttpMethod.Delete, $"{url}/rest/v1/character_relationships?id=eq.{relationshipId}&event_id=eq.{eventId}");
+        }
+
+        AddHeaders(req, key!);
+        var resp = await httpClient.SendAsync(req);
+        return resp.IsSuccessStatusCode ? Results.NoContent() : Results.Problem($"Failed to delete character relationship: {resp.StatusCode}");
+    }
+
+    private static async Task<SupabaseCharacterRelationshipRow?> GetCharacterRelationship(Guid eventId, Guid characterId, Guid relationshipId, string url, string key, HttpClient httpClient)
+    {
+        var query = $"{url}/rest/v1/character_relationships" +
+                    $"?id=eq.{relationshipId}" +
+                    $"&event_id=eq.{eventId}" +
+                    $"&or=(source_character_id.eq.{characterId},target_character_id.eq.{characterId})" +
+                    "&select=id,event_id,source_character_id,target_character_id,relation_type,relation_mode,mirror_group_id,is_auto_mirror,is_active,description,created_at,updated_at" +
+                    "&limit=1";
+        var req = new HttpRequestMessage(HttpMethod.Get, query);
+        AddHeaders(req, key);
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return null;
+        var rows = await resp.Content.ReadFromJsonAsync<List<SupabaseCharacterRelationshipRow>>();
+        return rows?.FirstOrDefault();
+    }
+
+    private static async Task<Dictionary<Guid, string>> GetCharacterNames(List<Guid> characterIds, string url, string key, HttpClient httpClient)
+    {
+        if (characterIds.Count == 0) return new Dictionary<Guid, string>();
+        var idFilter = string.Join(",", characterIds.Select(id => $"\"{id}\""));
+        var req = new HttpRequestMessage(HttpMethod.Get, $"{url}/rest/v1/characters?id=in.({idFilter})&select=id,name");
+        AddHeaders(req, key);
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return new Dictionary<Guid, string>();
+        var rows = await resp.Content.ReadFromJsonAsync<List<SupabaseCharacterNameRow>>() ?? [];
+        return rows.ToDictionary(r => r.id, r => r.name);
+    }
+
+    private static bool IsValidRelationshipMode(string mode) =>
+        string.Equals(mode, "directional", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(mode, "auto_mirrored", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAutoMirrored(string mode) =>
+        string.Equals(mode, "auto_mirrored", StringComparison.OrdinalIgnoreCase);
+
+    // ─── Item Assignments ───────────────────────────────────────────────
+
+    private static async Task<IResult> ListCharacterItems(Guid eventId, Guid characterId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanRead) return Results.Forbid();
+        if (!await CharacterExists(eventId, characterId, url!, key!, httpClient, includeDeleted: false)) return Results.NotFound();
+
+        var items = await GetAssignedItemsAsync(eventId, characterId, url!, key!, httpClient);
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> AssignItemToCharacter(Guid eventId, Guid characterId, Guid itemId, ClaimsPrincipal user, [FromBody] AssignItemToCharacterRequest request, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+        if (!await CharacterExists(eventId, characterId, url!, key!, httpClient, includeDeleted: false)) return Results.NotFound();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"{url}/rest/v1/narrative_item_character_assignments?on_conflict=item_id,character_id");
+        req.Headers.Add("Prefer", "return=representation,resolution=merge-duplicates");
+        AddHeaders(req, key!);
+        req.Content = JsonContent.Create(new
+        {
+            event_id = eventId,
+            item_id = itemId,
+            character_id = characterId,
+            assigned_by = UserId(user),
+            notes = request.Notes
+        });
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return Results.Problem($"Failed to assign item: {resp.StatusCode}");
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> RemoveItemFromCharacter(Guid eventId, Guid characterId, Guid itemId, ClaimsPrincipal user, IConfiguration config, HttpClient httpClient, CharacterAuthorizationService authz)
+    {
+        if (!TryConfig(config, out var url, out var key, out var error)) return error!;
+        var access = await authz.ResolveEventAccessAsync(user, eventId, url!, key!);
+        if (!access.CanWrite) return Results.Forbid();
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"{url}/rest/v1/narrative_item_character_assignments?event_id=eq.{eventId}&item_id=eq.{itemId}&character_id=eq.{characterId}");
+        AddHeaders(req, key!);
+        var resp = await httpClient.SendAsync(req);
+        return resp.IsSuccessStatusCode ? Results.NoContent() : Results.Problem($"Failed to remove item assignment: {resp.StatusCode}");
+    }
+
+    private static async Task<IReadOnlyList<CharacterAssignedItemDto>> GetAssignedItemsAsync(Guid eventId, Guid characterId, string url, string key, HttpClient httpClient)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"{url}/rest/v1/narrative_item_character_assignments" +
+            $"?event_id=eq.{eventId}&character_id=eq.{characterId}" +
+            "&select=item_id,character_id,assigned_at,notes,item:narrative_items(id,name,description,status)" +
+            "&order=assigned_at.desc");
+        AddHeaders(req, key);
+        var resp = await httpClient.SendAsync(req);
+        if (!resp.IsSuccessStatusCode) return [];
+        var rows = await resp.Content.ReadFromJsonAsync<List<SupabaseItemAssignmentJoinRow>>() ?? [];
+        return rows
+            .Where(r => r.item is not null)
+            .Select(r => new CharacterAssignedItemDto(r.item_id, r.item!.name, r.item.description, r.item.status, r.notes, r.assigned_at))
+            .ToList();
     }
 }

--- a/backend/Sancho.Modules/Character/CharacterModels.cs
+++ b/backend/Sancho.Modules/Character/CharacterModels.cs
@@ -124,6 +124,30 @@ public record NarrativeRelationshipDto(
     string? Description
 );
 
+public record CharacterRelationshipDto(
+    Guid Id,
+    Guid EventId,
+    Guid SourceCharacterId,
+    Guid TargetCharacterId,
+    string TargetCharacterName,
+    string RelationType,
+    string RelationMode,
+    Guid? MirrorGroupId,
+    bool IsAutoMirror,
+    string? Description,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);
+
+public record CharacterAssignedItemDto(
+    Guid ItemId,
+    string ItemName,
+    string? ItemDescription,
+    string? ItemStatus,
+    string? AssignmentNotes,
+    DateTimeOffset AssignedAt
+);
+
 public record NarrativeQuestDto(
     Guid QuestId,
     string Name,
@@ -135,7 +159,8 @@ public record NarrativeQuestDto(
 public record CharacterNarrativeLinksDto(
     IReadOnlyList<NarrativeFactionDto> Factions,
     IReadOnlyList<NarrativeRelationshipDto> Relationships,
-    IReadOnlyList<NarrativeQuestDto> Quests
+    IReadOnlyList<NarrativeQuestDto> Quests,
+    IReadOnlyList<CharacterAssignedItemDto> Items
 );
 
 public record CreateCharacterRequest(
@@ -221,6 +246,22 @@ public record UpdateCharacterAttachmentRequest(
     string? NewGoogleDriveUrl
 );
 
+public record CreateCharacterRelationshipRequest(
+    Guid TargetCharacterId,
+    string RelationType,
+    string RelationMode,
+    string? Description
+);
+
+public record UpdateCharacterRelationshipRequest(
+    string? RelationType,
+    string? Description
+);
+
+public record AssignItemToCharacterRequest(
+    string? Notes
+);
+
 public record CharacterDeleteRequest(
     string? Reason
 );
@@ -282,4 +323,39 @@ internal record SupabaseEventStatusRow(
 
 internal record SupabaseIdRow(
     Guid id
+);
+
+internal record SupabaseCharacterRelationshipRow(
+    Guid id,
+    [property: JsonPropertyName("event_id")] Guid event_id,
+    [property: JsonPropertyName("source_character_id")] Guid source_character_id,
+    [property: JsonPropertyName("target_character_id")] Guid target_character_id,
+    [property: JsonPropertyName("relation_type")] string relation_type,
+    [property: JsonPropertyName("relation_mode")] string relation_mode,
+    [property: JsonPropertyName("mirror_group_id")] Guid? mirror_group_id,
+    [property: JsonPropertyName("is_auto_mirror")] bool is_auto_mirror,
+    [property: JsonPropertyName("is_active")] bool is_active,
+    string? description,
+    [property: JsonPropertyName("created_at")] DateTimeOffset created_at,
+    [property: JsonPropertyName("updated_at")] DateTimeOffset updated_at
+);
+
+internal record SupabaseCharacterNameRow(
+    Guid id,
+    string name
+);
+
+internal record SupabaseItemAssignmentJoinRow(
+    [property: JsonPropertyName("item_id")] Guid item_id,
+    [property: JsonPropertyName("character_id")] Guid character_id,
+    [property: JsonPropertyName("assigned_at")] DateTimeOffset assigned_at,
+    string? notes,
+    [property: JsonPropertyName("item")] SupabaseItemInfoRow? item
+);
+
+internal record SupabaseItemInfoRow(
+    Guid id,
+    string name,
+    string? description,
+    string? status
 );

--- a/frontend/app/[locale]/(app)/characters/[eventId]/[characterId]/page.tsx
+++ b/frontend/app/[locale]/(app)/characters/[eventId]/[characterId]/page.tsx
@@ -45,12 +45,14 @@ export default async function CharacterDetailPage({
     try {
         // Fetch all data in parallel — event, character, abilities, attachments, and narrative links
         // are all independent and can be resolved simultaneously.
-        const [event, character, abilities, attachments, narrativeLinks] = await Promise.all([
+        const [event, character, abilities, attachments, narrativeLinks, relationships, items] = await Promise.all([
             eventsApi.getEvent(token, eventId),
             charactersApi.getCharacter(token, eventId, characterId),
             charactersApi.listAbilities(token, eventId, characterId),
             charactersApi.listAttachments(token, eventId, characterId),
-            charactersApi.getNarrativeLinks(token, eventId, characterId)
+            charactersApi.getNarrativeLinks(token, eventId, characterId),
+            charactersApi.listRelationships(token, eventId, characterId),
+            charactersApi.listCharacterItems(token, eventId, characterId)
         ]);
 
         return (
@@ -61,6 +63,8 @@ export default async function CharacterDetailPage({
                     initialAbilities={abilities}
                     initialAttachments={attachments}
                     initialNarrativeLinks={narrativeLinks}
+                    initialRelationships={relationships}
+                    initialItems={items}
                     canWrite={canWrite}
                     token={token}
                 />

--- a/frontend/components/characters/character-detail.tsx
+++ b/frontend/components/characters/character-detail.tsx
@@ -9,6 +9,8 @@ import {
     CharacterAbilityDto,
     CharacterAttachmentDto,
     CharacterNarrativeLinksDto,
+    CharacterRelationshipDto,
+    CharacterAssignedItemDto,
     charactersApi
 } from "@/utils/characters-api";
 import { EventDetailDto } from "@/utils/events-api";
@@ -28,6 +30,8 @@ import { AbilitiesPanel } from "./abilities-panel";
 import { AttachmentsPanel } from "./attachments-panel";
 import { PhotoUpload } from "./photo-upload";
 import { NarrativePanel } from "./narrative-panel";
+import { CharacterRelationshipsPanel } from "./character-relationships-panel";
+import { CharacterItemsPanel } from "./character-items-panel";
 import { RichTextView } from "@/components/ui/rich-text-view";
 // Lazy-load the rich-text editor: Tiptap adds ~150-200 KB to the bundle and is
 // only needed when the user actively edits biography or notes.
@@ -42,6 +46,8 @@ interface CharacterDetailProps {
     initialAbilities: CharacterAbilityDto[];
     initialAttachments: CharacterAttachmentDto[];
     initialNarrativeLinks: CharacterNarrativeLinksDto;
+    initialRelationships: CharacterRelationshipDto[];
+    initialItems: CharacterAssignedItemDto[];
     canWrite: boolean;
     token: string;
 }
@@ -52,6 +58,8 @@ export function CharacterDetail({
     initialAbilities,
     initialAttachments,
     initialNarrativeLinks,
+    initialRelationships,
+    initialItems,
     canWrite,
     token
 }: CharacterDetailProps) {
@@ -209,16 +217,16 @@ export function CharacterDetail({
             <Tabs defaultValue="profile" className="w-full">
                 <TabsList className="w-full justify-start border-b rounded-none h-auto bg-transparent p-0">
                     <TabsTrigger value="profile" className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-6 py-3">
-                        Profile
+                        {t("detail.tabs.profile")}
                     </TabsTrigger>
                     <TabsTrigger value="abilities" className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-6 py-3">
-                        Abilities <span className="ml-2 bg-muted text-foreground px-2 py-0.5 rounded-full text-xs">{character.abilitiesCount}</span>
+                        {t("detail.tabs.abilities")} <span className="ml-2 bg-muted text-foreground px-2 py-0.5 rounded-full text-xs">{character.abilitiesCount}</span>
                     </TabsTrigger>
                     <TabsTrigger value="attachments" className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-6 py-3">
-                        Attachments <span className="ml-2 bg-muted text-foreground px-2 py-0.5 rounded-full text-xs">{character.attachmentsCount}</span>
+                        {t("detail.tabs.attachments")} <span className="ml-2 bg-muted text-foreground px-2 py-0.5 rounded-full text-xs">{character.attachmentsCount}</span>
                     </TabsTrigger>
                     <TabsTrigger value="narrative" className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-6 py-3">
-                        Narrative
+                        {t("detail.tabs.narrative")}
                     </TabsTrigger>
                 </TabsList>
 
@@ -302,7 +310,23 @@ export function CharacterDetail({
                     />
                 </TabsContent>
 
-                <TabsContent value="narrative" className="mt-6">
+                <TabsContent value="narrative" className="mt-6 space-y-8">
+                    <CharacterRelationshipsPanel
+                        characterId={character.id}
+                        eventId={event.id}
+                        initialRelationships={initialRelationships}
+                        canWrite={canWrite && !isDeleted}
+                        token={token}
+                    />
+
+                    <CharacterItemsPanel
+                        characterId={character.id}
+                        eventId={event.id}
+                        initialItems={initialItems}
+                        canWrite={canWrite && !isDeleted}
+                        token={token}
+                    />
+
                     <NarrativePanel
                         eventName={event.name}
                         characterName={character.name}

--- a/frontend/components/characters/character-items-panel.tsx
+++ b/frontend/components/characters/character-items-panel.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { CharacterAssignedItemDto, charactersApi } from "@/utils/characters-api";
+import { NarrativeItemDto, narrativeApi } from "@/utils/narrative-api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Trash2, Plus, Loader2, Check, ChevronsUpDown, Package } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface CharacterItemsPanelProps {
+    characterId: string;
+    eventId: string;
+    initialItems: CharacterAssignedItemDto[];
+    canWrite: boolean;
+    token: string;
+}
+
+export function CharacterItemsPanel({ characterId, eventId, initialItems, canWrite, token }: CharacterItemsPanelProps) {
+    const t = useTranslations("characters");
+    const [items, setItems] = useState<CharacterAssignedItemDto[]>(initialItems);
+
+    const [availableItems, setAvailableItems] = useState<NarrativeItemDto[]>([]);
+    const [selectedItemId, setSelectedItemId] = useState("");
+    const [notes, setNotes] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const allItems = await narrativeApi.listItems(token, eventId);
+                setAvailableItems(allItems);
+            } catch (e) {
+                console.error(e);
+            }
+        };
+        fetchData();
+    }, [eventId, token]);
+
+    const handleAssign = async () => {
+        if (!selectedItemId) return;
+        setIsSaving(true);
+        try {
+            await charactersApi.assignItem(token, eventId, characterId, selectedItemId, {
+                notes: notes.trim() || null
+            });
+
+            // Re-fetch to get updated list
+            const latest = await charactersApi.listCharacterItems(token, eventId, characterId);
+            setItems(latest);
+
+            setSelectedItemId("");
+            setNotes("");
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleRemove = async (itemId: string) => {
+        if (!confirm(t("items.confirmRemove"))) return;
+        try {
+            await charactersApi.removeItem(token, eventId, characterId, itemId);
+            setItems(prev => prev.filter(i => i.itemId !== itemId));
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    // Filter out already-assigned items from picker
+    const assignedItemIds = new Set(items.map(i => i.itemId));
+    const unassignedItems = availableItems.filter(i => !assignedItemIds.has(i.id));
+
+    const statusBadgeClass = (status: string | null) => {
+        if (!status) return "";
+        const s = status.toLowerCase();
+        if (s === "final") return "border-green-300 bg-green-100 text-green-800";
+        if (s === "ready") return "border-blue-300 bg-blue-100 text-blue-800";
+        return "border-amber-300 bg-amber-100 text-amber-800";
+    };
+
+    return (
+        <div className="space-y-4">
+            <h2 className="text-lg font-semibold tracking-tight flex items-center gap-2">
+                <Package className="h-5 w-5 text-orange-500" />
+                {t("items.title")}
+            </h2>
+
+            {canWrite && (
+                <div className="flex flex-col sm:flex-row items-end gap-4 p-4 rounded-lg border bg-card flex-wrap">
+                    <div className="space-y-1 flex-1 min-w-[200px]">
+                        <label className="text-sm font-medium">{t("items.selectItem")}</label>
+                        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    role="combobox"
+                                    aria-expanded={pickerOpen}
+                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                >
+                                    {selectedItemId
+                                        ? availableItems.find(i => i.id === selectedItemId)?.name
+                                        : t("items.selectItem")}
+                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-[300px] p-0" align="start">
+                                <Command>
+                                    <CommandInput placeholder={t("items.searchItem")} />
+                                    <CommandList>
+                                        <CommandEmpty>No results.</CommandEmpty>
+                                        <CommandGroup>
+                                            {unassignedItems.map((item) => (
+                                                <CommandItem
+                                                    key={item.id}
+                                                    value={item.name}
+                                                    onSelect={() => {
+                                                        setSelectedItemId(selectedItemId === item.id ? "" : item.id);
+                                                        setPickerOpen(false);
+                                                    }}
+                                                >
+                                                    <Check
+                                                        className={cn(
+                                                            "mr-2 h-4 w-4",
+                                                            selectedItemId === item.id ? "opacity-100" : "opacity-0"
+                                                        )}
+                                                    />
+                                                    {item.name}
+                                                </CommandItem>
+                                            ))}
+                                        </CommandGroup>
+                                    </CommandList>
+                                </Command>
+                            </PopoverContent>
+                        </Popover>
+                    </div>
+
+                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[200px]">
+                        <label className="text-sm font-medium">{t("items.notes")}</label>
+                        <Input
+                            value={notes}
+                            placeholder={t("items.notesPlaceholder")}
+                            onChange={(e) => setNotes(e.target.value)}
+                        />
+                    </div>
+
+                    <Button onClick={handleAssign} disabled={!selectedItemId || isSaving}>
+                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
+                        {t("items.assign")}
+                    </Button>
+                </div>
+            )}
+
+            <div className="rounded-md border bg-card">
+                <div className="grid grid-cols-[2fr_2fr_1fr_2fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">
+                    <div>{t("fields.name")}</div>
+                    <div>{t("relationships.description")}</div>
+                    <div>Status</div>
+                    <div>{t("items.notes")}</div>
+                    {canWrite && <div className="w-10"></div>}
+                </div>
+                {items.length === 0 ? (
+                    <div className="p-8 text-center text-muted-foreground">{t("items.emptyState")}</div>
+                ) : (
+                    <div className="divide-y">
+                        {items.map(item => (
+                            <div key={item.itemId} className="grid grid-cols-[2fr_2fr_1fr_2fr_auto] gap-4 p-4 items-center">
+                                <div className="font-medium">{item.itemName}</div>
+                                <div className="text-sm text-muted-foreground truncate" title={item.itemDescription || ""}>
+                                    {item.itemDescription || "—"}
+                                </div>
+                                <div>
+                                    {item.itemStatus && (
+                                        <Badge variant="outline" className={`text-[10px] uppercase ${statusBadgeClass(item.itemStatus)}`}>
+                                            {item.itemStatus}
+                                        </Badge>
+                                    )}
+                                </div>
+                                <div className="text-sm text-muted-foreground truncate" title={item.assignmentNotes || ""}>
+                                    {item.assignmentNotes || "—"}
+                                </div>
+                                {canWrite && (
+                                    <Button variant="ghost" size="icon" onClick={() => handleRemove(item.itemId)} className="text-destructive">
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/characters/character-relationships-panel.tsx
+++ b/frontend/components/characters/character-relationships-panel.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { CharacterRelationshipDto, CharacterListItemDto, charactersApi } from "@/utils/characters-api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Trash2, Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface CharacterRelationshipsPanelProps {
+    characterId: string;
+    eventId: string;
+    initialRelationships: CharacterRelationshipDto[];
+    canWrite: boolean;
+    token: string;
+}
+
+export function CharacterRelationshipsPanel({ characterId, eventId, initialRelationships, canWrite, token }: CharacterRelationshipsPanelProps) {
+    const t = useTranslations("characters");
+    const [relationships, setRelationships] = useState<CharacterRelationshipDto[]>(initialRelationships);
+
+    const [characters, setCharacters] = useState<CharacterListItemDto[]>([]);
+    const [targetId, setTargetId] = useState("");
+    const [relationType, setRelationType] = useState("");
+    const [relationMode, setRelationMode] = useState("directional");
+    const [description, setDescription] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const chars = await charactersApi.listCharacters(token, eventId);
+                setCharacters(chars.filter(c => c.id !== characterId));
+            } catch (e) {
+                console.error(e);
+            }
+        };
+        fetchData();
+    }, [eventId, characterId, token]);
+
+    const handleAdd = async () => {
+        if (!targetId) return;
+        setIsSaving(true);
+        try {
+            await charactersApi.createRelationship(token, eventId, characterId, {
+                targetCharacterId: targetId,
+                relationType: relationType.trim() || "ally",
+                relationMode,
+                description: description.trim() || null
+            });
+
+            // Re-fetch to get auto-mirrored instances
+            const latest = await charactersApi.listRelationships(token, eventId, characterId);
+            setRelationships(latest);
+
+            setTargetId("");
+            setRelationType("");
+            setDescription("");
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleRemove = async (relId: string) => {
+        if (!confirm(t("relationships.confirmDelete"))) return;
+        try {
+            await charactersApi.deleteRelationship(token, eventId, characterId, relId);
+            setRelationships(prev => prev.filter(m => m.id !== relId));
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    const filteredRelationships = relationships.filter(rel => !rel.isAutoMirror);
+
+    return (
+        <div className="space-y-4">
+            <h2 className="text-lg font-semibold tracking-tight">{t("relationships.title")}</h2>
+
+            {canWrite && (
+                <div className="flex flex-col sm:flex-row items-end gap-4 p-4 rounded-lg border bg-card flex-wrap">
+                    <div className="space-y-1 flex-1 min-w-[200px]">
+                        <label className="text-sm font-medium">{t("relationships.target")}</label>
+                        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    role="combobox"
+                                    aria-expanded={pickerOpen}
+                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                >
+                                    {targetId
+                                        ? characters.find(c => c.id === targetId)?.name
+                                        : t("relationships.selectCharacter")}
+                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-[300px] p-0" align="start">
+                                <Command>
+                                    <CommandInput placeholder={t("relationships.searchCharacter")} />
+                                    <CommandList>
+                                        <CommandEmpty>No results.</CommandEmpty>
+                                        <CommandGroup>
+                                            {characters.map((char) => (
+                                                <CommandItem
+                                                    key={char.id}
+                                                    value={char.name}
+                                                    onSelect={() => {
+                                                        setTargetId(targetId === char.id ? "" : char.id);
+                                                        setPickerOpen(false);
+                                                    }}
+                                                >
+                                                    <Check
+                                                        className={cn(
+                                                            "mr-2 h-4 w-4",
+                                                            targetId === char.id ? "opacity-100" : "opacity-0"
+                                                        )}
+                                                    />
+                                                    {char.name}
+                                                </CommandItem>
+                                            ))}
+                                        </CommandGroup>
+                                    </CommandList>
+                                </Command>
+                            </PopoverContent>
+                        </Popover>
+                    </div>
+
+                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[150px]">
+                        <label className="text-sm font-medium">{t("relationships.type")}</label>
+                        <Input
+                            value={relationType}
+                            placeholder={t("relationships.typePlaceholder")}
+                            maxLength={100}
+                            onChange={(e) => setRelationType(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1 w-full sm:w-auto">
+                        <label className="text-sm font-medium">{t("relationships.mode")}</label>
+                        <select
+                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            value={relationMode}
+                            onChange={(e) => setRelationMode(e.target.value)}
+                        >
+                            <option value="directional">{t("relationships.directional")}</option>
+                            <option value="auto_mirrored">{t("relationships.mirrored")}</option>
+                        </select>
+                    </div>
+
+                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[150px]">
+                        <label className="text-sm font-medium">{t("relationships.description")}</label>
+                        <Input
+                            value={description}
+                            placeholder={t("relationships.descriptionPlaceholder")}
+                            onChange={(e) => setDescription(e.target.value)}
+                        />
+                    </div>
+
+                    <Button onClick={handleAdd} disabled={!targetId || isSaving}>
+                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
+                        {t("relationships.add")}
+                    </Button>
+                </div>
+            )}
+
+            <div className="rounded-md border bg-card">
+                <div className="grid grid-cols-[2fr_1fr_1fr_2fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">
+                    <div>{t("relationships.target")}</div>
+                    <div>{t("relationships.type")}</div>
+                    <div>{t("relationships.mode")}</div>
+                    <div>{t("relationships.description")}</div>
+                    {canWrite && <div className="w-10"></div>}
+                </div>
+                {filteredRelationships.length === 0 ? (
+                    <div className="p-8 text-center text-muted-foreground">{t("relationships.noRelationships")}</div>
+                ) : (
+                    <div className="divide-y">
+                        {filteredRelationships.map(rel => (
+                            <div key={rel.id} className="grid grid-cols-[2fr_1fr_1fr_2fr_auto] gap-4 p-4 items-center">
+                                <div className="font-medium">{rel.targetCharacterName}</div>
+                                <div><span className="capitalize">{rel.relationType}</span></div>
+                                <div className="text-muted-foreground text-sm">
+                                    {rel.relationMode === "directional" ? t("relationships.directional") : t("relationships.mirrored")}
+                                </div>
+                                <div className="text-sm text-muted-foreground truncate" title={rel.description || ""}>
+                                    {rel.description || "—"}
+                                </div>
+                                {canWrite && (
+                                    <Button variant="ghost" size="icon" onClick={() => handleRemove(rel.id)} className="text-destructive">
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/characters/narrative-graph/graph-filters.tsx
+++ b/frontend/components/characters/narrative-graph/graph-filters.tsx
@@ -7,9 +7,11 @@ export interface GraphFilterState {
     showCharacters: boolean;
     showFactions: boolean;
     showQuests: boolean;
+    showItems: boolean;
     showDirectRelationships: boolean;
     showFactionMemberships: boolean;
     showQuestParticipations: boolean;
+    showItemLinks: boolean;
 }
 
 interface GraphFiltersProps {
@@ -58,6 +60,11 @@ export function GraphFilters({ filters, onChange }: GraphFiltersProps) {
                                 checked={filters.showQuests}
                                 onChange={(v) => onChange("showQuests", v)}
                             />
+                            <FilterCheckbox
+                                label="Items"
+                                checked={filters.showItems}
+                                onChange={(v) => onChange("showItems", v)}
+                            />
                         </div>
                         <div className="space-y-1.5 pt-1 border-t border-slate-200 dark:border-slate-700">
                             <p className="text-[10px] uppercase tracking-wider text-slate-400 dark:text-slate-500 font-semibold">
@@ -77,6 +84,11 @@ export function GraphFilters({ filters, onChange }: GraphFiltersProps) {
                                 label="Quest links"
                                 checked={filters.showQuestParticipations}
                                 onChange={(v) => onChange("showQuestParticipations", v)}
+                            />
+                            <FilterCheckbox
+                                label="Item links"
+                                checked={filters.showItemLinks}
+                                onChange={(v) => onChange("showItemLinks", v)}
                             />
                         </div>
                     </div>

--- a/frontend/components/characters/narrative-graph/graph-legend.tsx
+++ b/frontend/components/characters/narrative-graph/graph-legend.tsx
@@ -10,6 +10,7 @@ const LEGEND_ITEMS = [
     { label: "Neutral", color: "#64748b", dashed: false },
     { label: "Faction", color: "#14b8a6", dashed: true },
     { label: "Quest", color: "#f97316", dashed: true },
+    { label: "Item", color: "#ea580c", dashed: true },
 ];
 
 export function GraphLegend() {

--- a/frontend/components/characters/narrative-graph/narrative-graph.tsx
+++ b/frontend/components/characters/narrative-graph/narrative-graph.tsx
@@ -18,12 +18,14 @@ import type {
     NarrativeRelationshipDto,
     NarrativeFactionDto,
     NarrativeQuestDto,
+    CharacterAssignedItemDto,
 } from "@/utils/characters-api";
 
 import { CentralNode } from "./nodes/central-node";
 import { CharacterNode } from "./nodes/character-node";
 import { FactionNode } from "./nodes/faction-node";
 import { QuestNode } from "./nodes/quest-node";
+import { ItemNode as ItemNodeComponent } from "./nodes/item-node";
 import { GraphLegend } from "./graph-legend";
 import { GraphFilters, type GraphFilterState } from "./graph-filters";
 import { useForceLayout } from "./use-force-layout";
@@ -46,6 +48,7 @@ const nodeTypes = {
     character: CharacterNode,
     faction: FactionNode,
     quest: QuestNode,
+    item: ItemNodeComponent,
 };
 
 // --- Props ---
@@ -57,6 +60,7 @@ interface NarrativeGraphProps {
     factions: NarrativeFactionDto[];
     questNodes: SampleQuestNode[];
     sampleCharacters: SampleCharacterNode[];
+    items?: CharacterAssignedItemDto[];
     hasRealData: boolean;
 }
 
@@ -66,7 +70,8 @@ function buildInitialNodes(
     characterName: string,
     relationships: NarrativeRelationshipDto[],
     factions: NarrativeFactionDto[],
-    questNodes: SampleQuestNode[]
+    questNodes: SampleQuestNode[],
+    items: CharacterAssignedItemDto[]
 ): Node[] {
     const nodes: Node[] = [
         {
@@ -136,6 +141,24 @@ function buildInitialNodes(
         });
     });
 
+    // Items assigned to the central character
+    items.forEach((item, i) => {
+        const angle = (2 * Math.PI * i) / Math.max(items.length, 1) + Math.PI / 2;
+        nodes.push({
+            id: `item-${item.itemId}`,
+            type: "item",
+            position: {
+                x: Math.cos(angle) * 300,
+                y: Math.sin(angle) * 300,
+            },
+            data: {
+                label: item.itemName,
+                status: item.itemStatus,
+            },
+            draggable: true,
+        });
+    });
+
     return nodes;
 }
 
@@ -143,7 +166,8 @@ function buildInitialEdges(
     relationships: NarrativeRelationshipDto[],
     factions: NarrativeFactionDto[],
     questNodes: SampleQuestNode[],
-    sampleCharacters: SampleCharacterNode[]
+    sampleCharacters: SampleCharacterNode[],
+    items: CharacterAssignedItemDto[]
 ): Edge[] {
     const edges: Edge[] = [];
 
@@ -227,6 +251,18 @@ function buildInitialEdges(
         });
     });
 
+    // Central → items (assigned items)
+    items.forEach((item) => {
+        edges.push({
+            id: `central-item-${item.itemId}`,
+            source: "central",
+            target: `item-${item.itemId}`,
+            style: { stroke: "#ea580c", strokeWidth: 1.5, strokeDasharray: "6 3" },
+            type: "default",
+            data: { edgeKind: "item" },
+        });
+    });
+
     return edges;
 }
 
@@ -238,16 +274,17 @@ export function NarrativeGraph({
     factions,
     questNodes,
     sampleCharacters,
+    items = [],
 }: NarrativeGraphProps) {
     // Build initial graph data
     const initialNodes = useMemo(
-        () => buildInitialNodes(characterName, relationships, factions, questNodes),
-        [characterName, relationships, factions, questNodes]
+        () => buildInitialNodes(characterName, relationships, factions, questNodes, items),
+        [characterName, relationships, factions, questNodes, items]
     );
 
     const initialEdges = useMemo(
-        () => buildInitialEdges(relationships, factions, questNodes, sampleCharacters),
-        [relationships, factions, questNodes, sampleCharacters]
+        () => buildInitialEdges(relationships, factions, questNodes, sampleCharacters, items),
+        [relationships, factions, questNodes, sampleCharacters, items]
     );
 
     // ReactFlow state
@@ -262,9 +299,11 @@ export function NarrativeGraph({
         showCharacters: true,
         showFactions: true,
         showQuests: true,
+        showItems: true,
         showDirectRelationships: true,
         showFactionMemberships: true,
         showQuestParticipations: true,
+        showItemLinks: true,
     });
 
     // Force layout
@@ -277,9 +316,10 @@ export function NarrativeGraph({
             if (node.type === "character" && !filters.showCharacters) hidden = true;
             if (node.type === "faction" && !filters.showFactions) hidden = true;
             if (node.type === "quest" && !filters.showQuests) hidden = true;
+            if (node.type === "item" && !filters.showItems) hidden = true;
             return { ...node, hidden };
         });
-    }, [nodes, filters.showCharacters, filters.showFactions, filters.showQuests]);
+    }, [nodes, filters.showCharacters, filters.showFactions, filters.showQuests, filters.showItems]);
 
     const filteredEdges = useMemo(() => {
         const visibleNodeIds = new Set(filteredNodes.filter((n) => !n.hidden).map((n) => n.id));
@@ -297,6 +337,7 @@ export function NarrativeGraph({
             if (edgeKind === "relationship" && !filters.showDirectRelationships) hidden = true;
             if (edgeKind === "faction" && !filters.showFactionMemberships) hidden = true;
             if (edgeKind === "quest" && !filters.showQuestParticipations) hidden = true;
+            if (edgeKind === "item" && !filters.showItemLinks) hidden = true;
 
             return { ...edge, hidden };
         });
@@ -306,6 +347,7 @@ export function NarrativeGraph({
         filters.showDirectRelationships,
         filters.showFactionMemberships,
         filters.showQuestParticipations,
+        filters.showItemLinks,
     ]);
 
     const handleFilterChange = useCallback((key: keyof GraphFilterState, value: boolean) => {
@@ -533,6 +575,7 @@ export function NarrativeGraph({
                         if (node.type === "central") return "fill-indigo-300";
                         if (node.type === "faction") return "fill-teal-300";
                         if (node.type === "quest") return "fill-amber-300";
+                        if (node.type === "item") return "fill-orange-300";
                         return "fill-slate-300";
                     }}
                     className="!bg-white/80 dark:!bg-slate-900/80"

--- a/frontend/components/characters/narrative-graph/nodes/item-node.tsx
+++ b/frontend/components/characters/narrative-graph/nodes/item-node.tsx
@@ -1,0 +1,47 @@
+import { Handle, Position } from "@xyflow/react";
+import { Badge } from "@/components/ui/badge";
+import { Package } from "lucide-react";
+
+interface ItemNodeData {
+    label: string;
+    status?: string | null;
+    [key: string]: unknown;
+}
+
+const STATUS_CLASS: Record<string, string> = {
+    draft: "border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-600 dark:bg-amber-900/50 dark:text-amber-300",
+    ready: "border-blue-300 bg-blue-100 text-blue-800 dark:border-blue-600 dark:bg-blue-900/50 dark:text-blue-300",
+    final: "border-green-300 bg-green-100 text-green-800 dark:border-green-600 dark:bg-green-900/50 dark:text-green-300",
+};
+
+function getStatusClass(status: string): string {
+    const key = status.toLowerCase();
+    return STATUS_CLASS[key] || STATUS_CLASS["draft"];
+}
+
+export function ItemNode({ data }: { data: ItemNodeData }) {
+    return (
+        <div className="relative px-3 py-2.5 rounded-lg border-2 border-orange-300 dark:border-orange-600 bg-orange-50 dark:bg-orange-950/60 shadow-md hover:shadow-lg hover:border-orange-400 dark:hover:border-orange-500 transition-all min-w-[150px] max-w-[210px]">
+            <Handle type="target" position={Position.Top} className="!w-2 !h-2 !bg-orange-400 !border-orange-300" />
+            <Handle type="source" position={Position.Bottom} className="!w-2 !h-2 !bg-orange-400 !border-orange-300" />
+            <Handle type="target" position={Position.Left} className="!w-2 !h-2 !bg-orange-400 !border-orange-300" />
+            <Handle type="source" position={Position.Right} className="!w-2 !h-2 !bg-orange-400 !border-orange-300" />
+
+            <div className="flex items-center gap-2.5">
+                <div className="shrink-0 h-8 w-8 rounded-md bg-orange-200 dark:bg-orange-800 flex items-center justify-center">
+                    <Package className="h-4 w-4 text-orange-700 dark:text-orange-300" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="font-semibold text-sm text-orange-900 dark:text-orange-100 truncate">
+                        {data.label}
+                    </div>
+                    {data.status && (
+                        <Badge variant="outline" className={`text-[10px] px-1.5 py-0 mt-1 ${getStatusClass(data.status)}`}>
+                            {data.status}
+                        </Badge>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/characters/narrative-graph/types.ts
+++ b/frontend/components/characters/narrative-graph/types.ts
@@ -1,4 +1,4 @@
-import type { NarrativeRelationshipDto, NarrativeQuestDto } from "@/utils/characters-api";
+import type { NarrativeRelationshipDto, NarrativeQuestDto, CharacterAssignedItemDto } from "@/utils/characters-api";
 
 export type SampleCharacterNode = {
     id: string;
@@ -13,3 +13,5 @@ export type SampleQuestNode = NarrativeQuestDto & {
     kind: "Quest" | "Plotline";
     participantIds: string[];
 };
+
+export type ItemNode = CharacterAssignedItemDto;

--- a/frontend/components/characters/narrative-panel.tsx
+++ b/frontend/components/characters/narrative-panel.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/utils/characters-api";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Users, Swords, Scroll, Shield, Sparkles } from "lucide-react";
+import { Swords, Scroll, Shield, Sparkles } from "lucide-react";
 import type { SampleCharacterNode, SampleQuestNode } from "./narrative-graph/types";
 
 const NarrativeGraph = dynamic(
@@ -158,8 +158,8 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
                 <div>
                     <h3 className="font-semibold">Managed in Narrative Module</h3>
                     <p className="text-sm text-muted-foreground">
-                        Factions, relationships, and quests are managed in the Narrative module.
-                        This tab provides a read-only consolidated view of how this character connects to the world story.
+                        Factions and quests are managed in the Narrative module.
+                        This section provides a read-only consolidated view of how this character connects to the world story.
                     </p>
                 </div>
             </div>
@@ -174,13 +174,7 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
                 </div>
             )}
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <Card>
-                    <CardHeader className="pb-2">
-                        <CardDescription>Relationships</CardDescription>
-                        <CardTitle className="text-2xl">{relationships.length}</CardTitle>
-                    </CardHeader>
-                </Card>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <Card>
                     <CardHeader className="pb-2">
                         <CardDescription>Factions</CardDescription>
@@ -196,36 +190,6 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Relationships */}
-                <Card>
-                    <CardHeader className="pb-3">
-                        <CardTitle className="flex items-center gap-2 text-lg">
-                            <Users className="h-5 w-5 text-indigo-500" />
-                            Relationships
-                        </CardTitle>
-                        <CardDescription>Direct connections to other characters</CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <ul className="space-y-4">
-                            {relationships.map((rel, index) => {
-                                return (
-                                    <li key={index} className="flex flex-col border-b last:border-0 pb-3 last:pb-0">
-                                        <div className="flex items-center justify-between mb-1">
-                                            <span className="font-medium">{rel.otherCharacterName}</span>
-                                            <Badge variant={RELATION_BADGE_VARIANT[rel.type]}>
-                                                {rel.type}
-                                            </Badge>
-                                        </div>
-                                        {rel.description && (
-                                            <p className="text-sm text-muted-foreground">{rel.description}</p>
-                                        )}
-                                    </li>
-                                );
-                            })}
-                        </ul>
-                    </CardContent>
-                </Card>
-
                 {/* Factions */}
                 <Card>
                     <CardHeader className="pb-3">
@@ -248,7 +212,7 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
                 </Card>
 
                 {/* Quests */}
-                <Card className="md:col-span-2">
+                <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="flex items-center gap-2 text-lg">
                             <Swords className="h-5 w-5 text-amber-500" />
@@ -257,7 +221,7 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
                         <CardDescription>Involvement in active and historical story elements</CardDescription>
                     </CardHeader>
                     <CardContent>
-                        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                        <div className="grid gap-4">
                             {quests.map((q, index) => (
                                 <div key={q.questId || index} className="border rounded-md p-3 hover:border-border/80 transition-colors">
                                     <div className="flex justify-between items-start mb-2 gap-2">
@@ -296,6 +260,7 @@ export function NarrativePanel({ eventName, characterName, links }: NarrativePan
                     factions={factions}
                     questNodes={questNodes}
                     sampleCharacters={SAMPLE_CHARACTERS}
+                    items={links.items}
                     hasRealData={hasRealData}
                 />
             </div>

--- a/frontend/messages/cs/characters.json
+++ b/frontend/messages/cs/characters.json
@@ -50,7 +50,7 @@
             "profile": "Profil",
             "abilities": "Schopnosti",
             "attachments": "Přílohy",
-            "narrative": "Příběh"
+            "narrative": "Vztahy a souvislosti"
         },
         "biography": {
             "title": "Životopis a veřejný příběh",
@@ -143,17 +143,11 @@
         "constraints": "Max 5 MB. JPG, PNG, WEBP."
     },
     "narrative": {
-        "notice": "Příběhová data jsou spravována v modulu Příběh (Narrative).",
+        "notice": "Frakce a úkoly jsou spravovány v modulu Příběh (Narrative).",
         "factions": {
             "title": "Frakce",
             "role": "Role",
             "emptyState": "Žádné členství ve frakcích."
-        },
-        "relationships": {
-            "title": "Vztahy",
-            "type": "Typ",
-            "description": "Popis",
-            "emptyState": "Žádné vztahy."
         },
         "quests": {
             "title": "Úkoly",
@@ -162,6 +156,32 @@
             "emptyState": "Žádné aktivní úkoly."
         },
         "graphLink": "Zobrazit celý graf vztahů"
+    },
+    "relationships": {
+        "title": "Vztahy mezi postavami",
+        "target": "Cílová postava",
+        "searchCharacter": "Hledat postavu...",
+        "selectCharacter": "Vybrat postavu...",
+        "type": "Typ",
+        "typePlaceholder": "např. Spojenec, Nepřítel, Mentor...",
+        "mode": "Režim",
+        "directional": "Jednosměrný",
+        "mirrored": "Zrcadlený",
+        "description": "Popis",
+        "descriptionPlaceholder": "Volitelný popis...",
+        "add": "Přidat",
+        "noRelationships": "Žádné vztahy mezi postavami.",
+        "confirmDelete": "Opravdu chcete smazat tento vztah?"
+    },
+    "items": {
+        "title": "Přiřazené předměty",
+        "searchItem": "Hledat předmět...",
+        "selectItem": "Vybrat předmět...",
+        "notes": "Poznámky",
+        "notesPlaceholder": "Volitelné poznámky k přiřazení...",
+        "assign": "Přiřadit",
+        "emptyState": "Žádné předměty nejsou přiřazeny této postavě.",
+        "confirmRemove": "Opravdu chcete odebrat toto přiřazení předmětu?"
     },
     "graph": {
         "title": "Graf vztahů",

--- a/frontend/messages/en/characters.json
+++ b/frontend/messages/en/characters.json
@@ -50,7 +50,7 @@
             "profile": "Profile",
             "abilities": "Abilities",
             "attachments": "Attachments",
-            "narrative": "Narrative"
+            "narrative": "Relationship map"
         },
         "biography": {
             "title": "Biography & Public Story",
@@ -143,17 +143,11 @@
         "constraints": "Max 5 MB. JPG, PNG, WEBP."
     },
     "narrative": {
-        "notice": "Narrative data is managed in the Narrative module.",
+        "notice": "Factions and quests are managed in the Narrative module.",
         "factions": {
             "title": "Factions",
             "role": "Role",
             "emptyState": "No faction memberships yet."
-        },
-        "relationships": {
-            "title": "Relationships",
-            "type": "Type",
-            "description": "Description",
-            "emptyState": "No relationships yet."
         },
         "quests": {
             "title": "Quests",
@@ -162,6 +156,32 @@
             "emptyState": "No active quests yet."
         },
         "graphLink": "View Full Relationship Graph"
+    },
+    "relationships": {
+        "title": "Character Relationships",
+        "target": "Target Character",
+        "searchCharacter": "Search character...",
+        "selectCharacter": "Select character...",
+        "type": "Type",
+        "typePlaceholder": "e.g. Ally, Enemy, Mentor...",
+        "mode": "Mode",
+        "directional": "One-way",
+        "mirrored": "Mirrored",
+        "description": "Description",
+        "descriptionPlaceholder": "Optional description...",
+        "add": "Add",
+        "noRelationships": "No character relationships yet.",
+        "confirmDelete": "Are you sure you want to delete this relationship?"
+    },
+    "items": {
+        "title": "Assigned Items",
+        "searchItem": "Search item...",
+        "selectItem": "Select item...",
+        "notes": "Notes",
+        "notesPlaceholder": "Optional assignment notes...",
+        "assign": "Assign",
+        "emptyState": "No items assigned to this character.",
+        "confirmRemove": "Are you sure you want to remove this item assignment?"
     },
     "graph": {
         "title": "Relationship Graph",

--- a/frontend/utils/characters-api.ts
+++ b/frontend/utils/characters-api.ts
@@ -98,10 +98,35 @@ export interface NarrativeQuestDto {
     status: string;
 }
 
+export interface CharacterRelationshipDto {
+    id: string;
+    eventId: string;
+    sourceCharacterId: string;
+    targetCharacterId: string;
+    targetCharacterName: string;
+    relationType: string;
+    relationMode: string;
+    mirrorGroupId: string | null;
+    isAutoMirror: boolean;
+    description: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CharacterAssignedItemDto {
+    itemId: string;
+    itemName: string;
+    itemDescription: string | null;
+    itemStatus: string | null;
+    assignmentNotes: string | null;
+    assignedAt: string;
+}
+
 export interface CharacterNarrativeLinksDto {
     factions: NarrativeFactionDto[];
     relationships: NarrativeRelationshipDto[];
     quests: NarrativeQuestDto[];
+    items: CharacterAssignedItemDto[];
 }
 
 // --- Requests ---
@@ -170,6 +195,22 @@ export interface AddGoogleDriveLinkRequest {
     url: string;
     displayName: string;
     documentStatus: string;
+}
+
+export interface CreateCharacterRelationshipRequest {
+    targetCharacterId: string;
+    relationType: string;
+    relationMode: string;
+    description?: string | null;
+}
+
+export interface UpdateCharacterRelationshipRequest {
+    relationType?: string;
+    description?: string | null;
+}
+
+export interface AssignItemToCharacterRequest {
+    notes?: string | null;
 }
 
 export interface UpdateCharacterAttachmentRequest {
@@ -364,6 +405,60 @@ export const charactersApi = {
     // Narrative
     getNarrativeLinks: (token: string, eventId: string, characterId: string) =>
         fetcher<CharacterNarrativeLinksDto>(`/api/events/${eventId}/characters/${characterId}/narrative-links`, {
+            headers: { Authorization: `Bearer ${token}` },
+        }),
+
+    // Character Relationships
+    listRelationships: (token: string, eventId: string, characterId: string) =>
+        fetcher<CharacterRelationshipDto[]>(`/api/events/${eventId}/characters/${characterId}/relationships`, {
+            headers: { Authorization: `Bearer ${token}` },
+        }),
+
+    createRelationship: (token: string, eventId: string, characterId: string, data: CreateCharacterRelationshipRequest) =>
+        fetcher<CharacterRelationshipDto>(`/api/events/${eventId}/characters/${characterId}/relationships`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        }),
+
+    updateRelationship: (token: string, eventId: string, characterId: string, relationshipId: string, data: UpdateCharacterRelationshipRequest) =>
+        fetcher<CharacterRelationshipDto>(`/api/events/${eventId}/characters/${characterId}/relationships/${relationshipId}`, {
+            method: "PATCH",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        }),
+
+    deleteRelationship: (token: string, eventId: string, characterId: string, relationshipId: string) =>
+        fetcher<void>(`/api/events/${eventId}/characters/${characterId}/relationships/${relationshipId}`, {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${token}` },
+        }),
+
+    // Item Assignments
+    listCharacterItems: (token: string, eventId: string, characterId: string) =>
+        fetcher<CharacterAssignedItemDto[]>(`/api/events/${eventId}/characters/${characterId}/items`, {
+            headers: { Authorization: `Bearer ${token}` },
+        }),
+
+    assignItem: (token: string, eventId: string, characterId: string, itemId: string, data: AssignItemToCharacterRequest) =>
+        fetcher<void>(`/api/events/${eventId}/characters/${characterId}/items/${itemId}`, {
+            method: "PUT",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        }),
+
+    removeItem: (token: string, eventId: string, characterId: string, itemId: string) =>
+        fetcher<void>(`/api/events/${eventId}/characters/${characterId}/items/${itemId}`, {
+            method: "DELETE",
             headers: { Authorization: `Bearer ${token}` },
         }),
 };

--- a/supabase/migrations/20260315150000_character_relationships.sql
+++ b/supabase/migrations/20260315150000_character_relationships.sql
@@ -1,0 +1,139 @@
+-- ============================================================
+-- Migration: Move character relationships from Narrative to Characters context
+-- Renames narrative_character_relationships -> character_relationships
+-- Adds auto-mirroring support columns
+-- Updates RLS to use characters module permissions
+-- ============================================================
+
+-- 1. Rename the table
+ALTER TABLE public.narrative_character_relationships RENAME TO character_relationships;
+
+-- 2. Rename 'type' to 'relation_type' for consistency with faction relationships
+ALTER TABLE public.character_relationships RENAME COLUMN type TO relation_type;
+
+-- 3. Add new columns for auto-mirroring support
+ALTER TABLE public.character_relationships
+  ADD COLUMN IF NOT EXISTS relation_mode TEXT NOT NULL DEFAULT 'directional',
+  ADD COLUMN IF NOT EXISTS mirror_group_id UUID,
+  ADD COLUMN IF NOT EXISTS is_auto_mirror BOOLEAN NOT NULL DEFAULT false;
+
+-- 4. Add constraints
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'character_relationships_relation_type_len' AND conrelid = 'public.character_relationships'::regclass) THEN
+    ALTER TABLE public.character_relationships ADD CONSTRAINT character_relationships_relation_type_len CHECK (char_length(relation_type) <= 100);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'character_relationships_relation_mode_check' AND conrelid = 'public.character_relationships'::regclass) THEN
+    ALTER TABLE public.character_relationships ADD CONSTRAINT character_relationships_relation_mode_check CHECK (relation_mode IN ('directional', 'auto_mirrored'));
+  END IF;
+END $$;
+
+-- 5. Drop old narrative-prefixed indexes
+DROP INDEX IF EXISTS idx_narrative_character_relationships_source;
+DROP INDEX IF EXISTS idx_narrative_character_relationships_target;
+
+-- 6. Create new indexes
+CREATE INDEX IF NOT EXISTS idx_character_relationships_event_source
+  ON public.character_relationships (event_id, source_character_id);
+CREATE INDEX IF NOT EXISTS idx_character_relationships_event_target
+  ON public.character_relationships (event_id, target_character_id);
+CREATE INDEX IF NOT EXISTS idx_character_relationships_mirror_group
+  ON public.character_relationships (mirror_group_id) WHERE mirror_group_id IS NOT NULL;
+
+-- 7. Drop old trigger and create new one
+DROP TRIGGER IF EXISTS trg_narrative_character_relationships_touch_updated_at ON public.character_relationships;
+
+CREATE OR REPLACE FUNCTION public.touch_character_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_character_relationships_touch_updated_at
+  BEFORE UPDATE ON public.character_relationships
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_character_updated_at();
+
+-- 8. Update RLS - drop old narrative policies, create character-module policies
+DROP POLICY IF EXISTS narrative_character_relationships_read ON public.character_relationships;
+DROP POLICY IF EXISTS narrative_character_relationships_write ON public.character_relationships;
+
+CREATE POLICY "Users can view character relationships" ON public.character_relationships
+  FOR SELECT
+  USING (
+    EXISTS (SELECT 1 FROM public.system_admins sa WHERE sa.user_id = auth.uid())
+    OR EXISTS (SELECT 1 FROM public.org_members om WHERE om.user_id = auth.uid() AND om.role = 'OrgOwner')
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_members em
+      JOIN public.events e ON e.id = em.event_id
+      WHERE em.user_id = auth.uid()
+        AND em.event_id = public.character_relationships.event_id
+        AND em.role = 'EventManager'
+        AND e.deleted_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_member_permissions p
+      JOIN public.events e ON e.id = p.event_id
+      WHERE p.user_id = auth.uid()
+        AND p.event_id = public.character_relationships.event_id
+        AND p.module = 'characters'
+        AND p.permission IN ('read', 'write')
+        AND e.deleted_at IS NULL
+    )
+  );
+
+CREATE POLICY "Users can manage character relationships" ON public.character_relationships
+  FOR ALL
+  USING (
+    EXISTS (SELECT 1 FROM public.system_admins sa WHERE sa.user_id = auth.uid())
+    OR EXISTS (SELECT 1 FROM public.org_members om WHERE om.user_id = auth.uid() AND om.role = 'OrgOwner')
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_members em
+      JOIN public.events e ON e.id = em.event_id
+      WHERE em.user_id = auth.uid()
+        AND em.event_id = public.character_relationships.event_id
+        AND em.role = 'EventManager'
+        AND e.status = 'active'
+        AND e.deleted_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_member_permissions p
+      JOIN public.events e ON e.id = p.event_id
+      WHERE p.user_id = auth.uid()
+        AND p.event_id = public.character_relationships.event_id
+        AND p.module = 'characters'
+        AND p.permission = 'write'
+        AND e.status = 'active'
+        AND e.deleted_at IS NULL
+    )
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.system_admins sa WHERE sa.user_id = auth.uid())
+    OR EXISTS (SELECT 1 FROM public.org_members om WHERE om.user_id = auth.uid() AND om.role = 'OrgOwner')
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_members em
+      JOIN public.events e ON e.id = em.event_id
+      WHERE em.user_id = auth.uid()
+        AND em.event_id = public.character_relationships.event_id
+        AND em.role = 'EventManager'
+        AND e.status = 'active'
+        AND e.deleted_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.event_member_permissions p
+      JOIN public.events e ON e.id = p.event_id
+      WHERE p.user_id = auth.uid()
+        AND p.event_id = public.character_relationships.event_id
+        AND p.module = 'characters'
+        AND p.permission = 'write'
+        AND e.status = 'active'
+        AND e.deleted_at IS NULL
+    )
+  );


### PR DESCRIPTION
## Overview
Adds comprehensive character relationship management and item assignment features with a new relationships panel and items panel in the character detail view.

## Backend Changes
- Added character relationships CRUD endpoints (list, create, update, delete)
- Implemented auto-mirrored relationship support with mirror group tracking
- Added item assignment endpoints for assigning/removing items from characters
- Extended narrative links to include assigned items
- New models for relationships and item assignments

## Frontend Changes
- New `CharacterRelationshipsPanel` component for managing character relationships
- New `CharacterItemsPanel` component for assigning items to characters
- Updated character detail page to fetch and display relationships and items
- Added narrative graph support for item nodes and filtering
- Enhanced translation keys for characters module
- Added utility functions in `characters-api.ts` for relationship and item operations

## Database
- New migration for character relationships table with support for directional and auto-mirrored modes
- Support for item-character assignments with metadata

## UI/UX
- Relationship creation with type, mode (directional/auto-mirrored), and description
- Item assignment with notes field
- Tabular display of assigned relationships and items
- Delete functionality with confirmation
- Combobox pickers for selecting target characters and items