### PR TITLE
refactor(characters): extract relationship and item forms to modal dialogs

### DIFF
--- a/Basic Information/UI_Implementation_Guide_Lines.md
+++ b/Basic Information/UI_Implementation_Guide_Lines.md
@@ -219,3 +219,72 @@ If the list is small and stable (<50), `Select` is acceptable. Otherwise use thi
   - keep picker open
 - Add/confirm i18n keys for all new labels and states.
 - Verify keyboard flow (type, arrows, Enter, Esc) works.
+
+## 15. Section Title with Modal Action Pattern
+
+Use this pattern when a data table/list section needs an "add" action. Instead of placing inline forms above the table (which crowds the UI), move the form into a modal dialog triggered by a compact `+` button next to the section title.
+
+### 15.1 When to use
+
+- Adding entities to a list/table section (relationships, item assignments, memberships, etc.)
+- Any section where the "add" form has 2+ fields and would otherwise consume vertical space inline
+- When the add action is secondary to browsing the existing data
+
+### 15.2 Title row structure
+
+Wrap the section heading and trigger button in a flex row:
+
+```tsx
+<div className="flex items-center justify-between">
+    <h2 className="text-lg font-semibold tracking-tight">{t("section.title")}</h2>
+    {canWrite && <AddEntityDialog ... />}
+</div>
+```
+
+### 15.3 Dialog component pattern
+
+Create a standalone dialog component file (e.g., `add-entity-dialog.tsx`) following the established create-dialog pattern:
+
+```tsx
+// Props: receive data as props from parent, use callback on success
+interface AddEntityDialogProps {
+    // ... context IDs (eventId, parentId, token)
+    candidates: CandidateDto[];        // parent owns the data
+    onEntityAdded: () => void;         // callback to trigger parent re-fetch
+}
+
+// Structure
+<Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+    <DialogTrigger asChild>
+        <Button variant="outline" size="icon">
+            <Plus className="h-4 w-4" />
+        </Button>
+    </DialogTrigger>
+    <DialogContent className="sm:max-w-[425px]">
+        {/* DialogHeader + Form (react-hook-form + zod) + DialogFooter */}
+    </DialogContent>
+</Dialog>
+```
+
+### 15.4 Key rules
+
+1. **Trigger is an icon-only `+` button** — `variant="outline" size="icon"` for compact appearance next to the title.
+2. **Dialog as a separate file** — keeps the parent panel focused on display/list logic.
+3. **Parent owns the data** — pass candidate lists as props; avoid duplicate fetching inside the dialog.
+4. **Callback on success** — dialog calls `onEntityAdded()` so the parent can re-fetch and update state.
+5. **Form resets on close** — handle in `onOpenChange`: `if (!v) form.reset()`.
+6. **Toast notifications** — use `sonner` toast for success/error feedback.
+7. **Conditional rendering** — only render the dialog trigger when `canWrite` is true.
+
+### 15.5 Popover-in-Dialog caveat
+
+When using a `Popover` + `Command` combobox picker inside a `Dialog`, set `modal={false}` on the `Popover` to prevent focus-trap conflicts between the two Radix portals:
+
+```tsx
+<Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+```
+
+### 15.6 Reference implementations
+
+- `frontend/components/characters/add-relationship-dialog.tsx` — 4-field form with combobox picker and Select
+- `frontend/components/characters/assign-item-dialog.tsx` — 2-field form with combobox picker

--- a/frontend/components/characters/add-relationship-dialog.tsx
+++ b/frontend/components/characters/add-relationship-dialog.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { CharacterListItemDto, charactersApi } from "@/utils/characters-api";
+
+interface AddRelationshipDialogProps {
+    characterId: string;
+    eventId: string;
+    token: string;
+    characters: CharacterListItemDto[];
+    onRelationshipAdded: () => void;
+}
+
+export function AddRelationshipDialog({ characterId, eventId, token, characters, onRelationshipAdded }: AddRelationshipDialogProps) {
+    const t = useTranslations("characters");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const formSchema = z.object({
+        targetCharacterId: z.string().min(1, t("validation.targetRequired")),
+        relationType: z.string().optional(),
+        relationMode: z.string(),
+        description: z.string().optional(),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            targetCharacterId: "",
+            relationType: "",
+            relationMode: "directional",
+            description: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await charactersApi.createRelationship(token, eventId, characterId, {
+                targetCharacterId: values.targetCharacterId,
+                relationType: values.relationType?.trim() || "ally",
+                relationMode: values.relationMode,
+                description: values.description?.trim() || null,
+            });
+
+            toast.success(t("notifications.relationshipAdded"));
+            setOpen(false);
+            form.reset();
+            onRelationshipAdded();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("errors.relationshipFailed"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("dialogs.addRelationship.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("dialogs.addRelationship.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="targetCharacterId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("relationships.target")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? characters.find(c => c.id === field.value)?.name
+                                                        : t("relationships.selectCharacter")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[300px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("relationships.searchCharacter")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("relationships.selectCharacter")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {characters.map((char) => (
+                                                                <CommandItem
+                                                                    key={char.id}
+                                                                    value={char.name}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === char.id ? "" : char.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            field.value === char.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    {char.name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="relationType"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("relationships.type")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("relationships.typePlaceholder")}
+                                            maxLength={100}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="relationMode"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("relationships.mode")}</FormLabel>
+                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                        <FormControl>
+                                            <SelectTrigger className="w-full">
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value="directional">{t("relationships.directional")}</SelectItem>
+                                            <SelectItem value="auto_mirrored">{t("relationships.mirrored")}</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="description"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("relationships.description")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("relationships.descriptionPlaceholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("dialogs.common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("dialogs.addRelationship.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/characters/assign-item-dialog.tsx
+++ b/frontend/components/characters/assign-item-dialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { charactersApi } from "@/utils/characters-api";
+import { NarrativeItemDto } from "@/utils/narrative-api";
+
+interface AssignItemDialogProps {
+    characterId: string;
+    eventId: string;
+    token: string;
+    availableItems: NarrativeItemDto[];
+    onItemAssigned: () => void;
+}
+
+export function AssignItemDialog({ characterId, eventId, token, availableItems, onItemAssigned }: AssignItemDialogProps) {
+    const t = useTranslations("characters");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const formSchema = z.object({
+        itemId: z.string().min(1, t("validation.itemRequired")),
+        notes: z.string().optional(),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            itemId: "",
+            notes: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await charactersApi.assignItem(token, eventId, characterId, values.itemId, {
+                notes: values.notes?.trim() || null,
+            });
+
+            toast.success(t("notifications.itemAssigned"));
+            setOpen(false);
+            form.reset();
+            onItemAssigned();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("errors.itemAssignFailed"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("dialogs.assignItem.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("dialogs.assignItem.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="itemId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("items.selectItem")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? availableItems.find(i => i.id === field.value)?.name
+                                                        : t("items.selectItem")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[300px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("items.searchItem")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("items.selectItem")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {availableItems.map((item) => (
+                                                                <CommandItem
+                                                                    key={item.id}
+                                                                    value={item.name}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === item.id ? "" : item.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            field.value === item.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    {item.name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="notes"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("items.notes")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("items.notesPlaceholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("dialogs.common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("dialogs.assignItem.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/characters/character-items-panel.tsx
+++ b/frontend/components/characters/character-items-panel.tsx
@@ -5,23 +5,9 @@ import { useTranslations } from "next-intl";
 import { CharacterAssignedItemDto, charactersApi } from "@/utils/characters-api";
 import { NarrativeItemDto, narrativeApi } from "@/utils/narrative-api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Trash2, Plus, Loader2, Check, ChevronsUpDown, Package } from "lucide-react";
+import { Trash2, Package } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-} from "@/components/ui/command";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { AssignItemDialog } from "./assign-item-dialog";
 
 interface CharacterItemsPanelProps {
     characterId: string;
@@ -36,10 +22,6 @@ export function CharacterItemsPanel({ characterId, eventId, initialItems, canWri
     const [items, setItems] = useState<CharacterAssignedItemDto[]>(initialItems);
 
     const [availableItems, setAvailableItems] = useState<NarrativeItemDto[]>([]);
-    const [selectedItemId, setSelectedItemId] = useState("");
-    const [notes, setNotes] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
-    const [pickerOpen, setPickerOpen] = useState(false);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -53,24 +35,12 @@ export function CharacterItemsPanel({ characterId, eventId, initialItems, canWri
         fetchData();
     }, [eventId, token]);
 
-    const handleAssign = async () => {
-        if (!selectedItemId) return;
-        setIsSaving(true);
+    const refreshItems = async () => {
         try {
-            await charactersApi.assignItem(token, eventId, characterId, selectedItemId, {
-                notes: notes.trim() || null
-            });
-
-            // Re-fetch to get updated list
             const latest = await charactersApi.listCharacterItems(token, eventId, characterId);
             setItems(latest);
-
-            setSelectedItemId("");
-            setNotes("");
-        } catch (error) {
-            console.error(error);
-        } finally {
-            setIsSaving(false);
+        } catch (e) {
+            console.error(e);
         }
     };
 
@@ -98,75 +68,21 @@ export function CharacterItemsPanel({ characterId, eventId, initialItems, canWri
 
     return (
         <div className="space-y-4">
-            <h2 className="text-lg font-semibold tracking-tight flex items-center gap-2">
-                <Package className="h-5 w-5 text-orange-500" />
-                {t("items.title")}
-            </h2>
-
-            {canWrite && (
-                <div className="flex flex-col sm:flex-row items-end gap-4 p-4 rounded-lg border bg-card flex-wrap">
-                    <div className="space-y-1 flex-1 min-w-[200px]">
-                        <label className="text-sm font-medium">{t("items.selectItem")}</label>
-                        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    aria-expanded={pickerOpen}
-                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
-                                >
-                                    {selectedItemId
-                                        ? availableItems.find(i => i.id === selectedItemId)?.name
-                                        : t("items.selectItem")}
-                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-[300px] p-0" align="start">
-                                <Command>
-                                    <CommandInput placeholder={t("items.searchItem")} />
-                                    <CommandList>
-                                        <CommandEmpty>No results.</CommandEmpty>
-                                        <CommandGroup>
-                                            {unassignedItems.map((item) => (
-                                                <CommandItem
-                                                    key={item.id}
-                                                    value={item.name}
-                                                    onSelect={() => {
-                                                        setSelectedItemId(selectedItemId === item.id ? "" : item.id);
-                                                        setPickerOpen(false);
-                                                    }}
-                                                >
-                                                    <Check
-                                                        className={cn(
-                                                            "mr-2 h-4 w-4",
-                                                            selectedItemId === item.id ? "opacity-100" : "opacity-0"
-                                                        )}
-                                                    />
-                                                    {item.name}
-                                                </CommandItem>
-                                            ))}
-                                        </CommandGroup>
-                                    </CommandList>
-                                </Command>
-                            </PopoverContent>
-                        </Popover>
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[200px]">
-                        <label className="text-sm font-medium">{t("items.notes")}</label>
-                        <Input
-                            value={notes}
-                            placeholder={t("items.notesPlaceholder")}
-                            onChange={(e) => setNotes(e.target.value)}
-                        />
-                    </div>
-
-                    <Button onClick={handleAssign} disabled={!selectedItemId || isSaving}>
-                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
-                        {t("items.assign")}
-                    </Button>
-                </div>
-            )}
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold tracking-tight flex items-center gap-2">
+                    <Package className="h-5 w-5 text-orange-500" />
+                    {t("items.title")}
+                </h2>
+                {canWrite && (
+                    <AssignItemDialog
+                        characterId={characterId}
+                        eventId={eventId}
+                        token={token}
+                        availableItems={unassignedItems}
+                        onItemAssigned={refreshItems}
+                    />
+                )}
+            </div>
 
             <div className="rounded-md border bg-card">
                 <div className="grid grid-cols-[2fr_2fr_1fr_2fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">

--- a/frontend/components/characters/character-relationships-panel.tsx
+++ b/frontend/components/characters/character-relationships-panel.tsx
@@ -4,22 +4,8 @@ import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { CharacterRelationshipDto, CharacterListItemDto, charactersApi } from "@/utils/characters-api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Trash2, Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-} from "@/components/ui/command";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { Trash2 } from "lucide-react";
+import { AddRelationshipDialog } from "./add-relationship-dialog";
 
 interface CharacterRelationshipsPanelProps {
     characterId: string;
@@ -34,12 +20,6 @@ export function CharacterRelationshipsPanel({ characterId, eventId, initialRelat
     const [relationships, setRelationships] = useState<CharacterRelationshipDto[]>(initialRelationships);
 
     const [characters, setCharacters] = useState<CharacterListItemDto[]>([]);
-    const [targetId, setTargetId] = useState("");
-    const [relationType, setRelationType] = useState("");
-    const [relationMode, setRelationMode] = useState("directional");
-    const [description, setDescription] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
-    const [pickerOpen, setPickerOpen] = useState(false);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -53,28 +33,12 @@ export function CharacterRelationshipsPanel({ characterId, eventId, initialRelat
         fetchData();
     }, [eventId, characterId, token]);
 
-    const handleAdd = async () => {
-        if (!targetId) return;
-        setIsSaving(true);
+    const refreshRelationships = async () => {
         try {
-            await charactersApi.createRelationship(token, eventId, characterId, {
-                targetCharacterId: targetId,
-                relationType: relationType.trim() || "ally",
-                relationMode,
-                description: description.trim() || null
-            });
-
-            // Re-fetch to get auto-mirrored instances
             const latest = await charactersApi.listRelationships(token, eventId, characterId);
             setRelationships(latest);
-
-            setTargetId("");
-            setRelationType("");
-            setDescription("");
-        } catch (error) {
-            console.error(error);
-        } finally {
-            setIsSaving(false);
+        } catch (e) {
+            console.error(e);
         }
     };
 
@@ -92,94 +56,18 @@ export function CharacterRelationshipsPanel({ characterId, eventId, initialRelat
 
     return (
         <div className="space-y-4">
-            <h2 className="text-lg font-semibold tracking-tight">{t("relationships.title")}</h2>
-
-            {canWrite && (
-                <div className="flex flex-col sm:flex-row items-end gap-4 p-4 rounded-lg border bg-card flex-wrap">
-                    <div className="space-y-1 flex-1 min-w-[200px]">
-                        <label className="text-sm font-medium">{t("relationships.target")}</label>
-                        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    aria-expanded={pickerOpen}
-                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
-                                >
-                                    {targetId
-                                        ? characters.find(c => c.id === targetId)?.name
-                                        : t("relationships.selectCharacter")}
-                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-[300px] p-0" align="start">
-                                <Command>
-                                    <CommandInput placeholder={t("relationships.searchCharacter")} />
-                                    <CommandList>
-                                        <CommandEmpty>No results.</CommandEmpty>
-                                        <CommandGroup>
-                                            {characters.map((char) => (
-                                                <CommandItem
-                                                    key={char.id}
-                                                    value={char.name}
-                                                    onSelect={() => {
-                                                        setTargetId(targetId === char.id ? "" : char.id);
-                                                        setPickerOpen(false);
-                                                    }}
-                                                >
-                                                    <Check
-                                                        className={cn(
-                                                            "mr-2 h-4 w-4",
-                                                            targetId === char.id ? "opacity-100" : "opacity-0"
-                                                        )}
-                                                    />
-                                                    {char.name}
-                                                </CommandItem>
-                                            ))}
-                                        </CommandGroup>
-                                    </CommandList>
-                                </Command>
-                            </PopoverContent>
-                        </Popover>
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[150px]">
-                        <label className="text-sm font-medium">{t("relationships.type")}</label>
-                        <Input
-                            value={relationType}
-                            placeholder={t("relationships.typePlaceholder")}
-                            maxLength={100}
-                            onChange={(e) => setRelationType(e.target.value)}
-                        />
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto">
-                        <label className="text-sm font-medium">{t("relationships.mode")}</label>
-                        <select
-                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                            value={relationMode}
-                            onChange={(e) => setRelationMode(e.target.value)}
-                        >
-                            <option value="directional">{t("relationships.directional")}</option>
-                            <option value="auto_mirrored">{t("relationships.mirrored")}</option>
-                        </select>
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[150px]">
-                        <label className="text-sm font-medium">{t("relationships.description")}</label>
-                        <Input
-                            value={description}
-                            placeholder={t("relationships.descriptionPlaceholder")}
-                            onChange={(e) => setDescription(e.target.value)}
-                        />
-                    </div>
-
-                    <Button onClick={handleAdd} disabled={!targetId || isSaving}>
-                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
-                        {t("relationships.add")}
-                    </Button>
-                </div>
-            )}
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold tracking-tight">{t("relationships.title")}</h2>
+                {canWrite && (
+                    <AddRelationshipDialog
+                        characterId={characterId}
+                        eventId={eventId}
+                        token={token}
+                        characters={characters}
+                        onRelationshipAdded={refreshRelationships}
+                    />
+                )}
+            </div>
 
             <div className="rounded-md border bg-card">
                 <div className="grid grid-cols-[2fr_1fr_1fr_2fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">

--- a/frontend/messages/cs/characters.json
+++ b/frontend/messages/cs/characters.json
@@ -224,6 +224,16 @@
             "description": "Vytvořit kopii této postavy. Schopnosti budou zkopírovány, ale fotka a přílohy ne.",
             "submit": "Duplikovat postavu"
         },
+        "addRelationship": {
+            "title": "Přidat vztah",
+            "description": "Vytvořte vztah mezi touto postavou a jinou.",
+            "submit": "Přidat vztah"
+        },
+        "assignItem": {
+            "title": "Přiřadit předmět",
+            "description": "Přiřaďte předmět z modulu Příběh této postavě.",
+            "submit": "Přiřadit předmět"
+        },
         "status": {
             "title": "Změnit stav postavy",
             "description": "Vyberte nový stav pro tuto postavu. Některé přechody mohou být omezeny.",
@@ -273,7 +283,9 @@
         "documentNameRequired": "Název dokumentu je povinný.",
         "documentUrlInvalid": "Zadejte platnou URL adresu Google Drive (docs.google.com, drive.google.com atd.).",
         "fileTooLarge": "Soubor musí být menší než 20 MB.",
-        "fileTypeNotAllowed": "Tento typ souboru není podporován."
+        "fileTypeNotAllowed": "Tento typ souboru není podporován.",
+        "targetRequired": "Vyberte cílovou postavu.",
+        "itemRequired": "Vyberte předmět."
     },
     "notifications": {
         "created": "Postava byla úspěšně vytvořena.",
@@ -287,11 +299,15 @@
         "abilityDeleted": "Schopnost smazána.",
         "attachmentAdded": "Dokument přidán.",
         "attachmentUpdated": "Dokument aktualizován.",
-        "attachmentDeleted": "Dokument odstraněn."
+        "attachmentDeleted": "Dokument odstraněn.",
+        "relationshipAdded": "Vztah byl úspěšně přidán.",
+        "itemAssigned": "Předmět byl úspěšně přiřazen."
     },
     "errors": {
         "loadFailed": "K načtení postav nedošlo.",
         "notFound": "Postava nebyla nalezena.",
-        "duplicateName": "Postava s tímto jménem v této události již existuje."
+        "duplicateName": "Postava s tímto jménem v této události již existuje.",
+        "relationshipFailed": "Nepodařilo se přidat vztah.",
+        "itemAssignFailed": "Nepodařilo se přiřadit předmět."
     }
 }

--- a/frontend/messages/en/characters.json
+++ b/frontend/messages/en/characters.json
@@ -224,6 +224,16 @@
             "description": "Create a copy of this character. Abilities will be copied, but photo and attachments will not.",
             "submit": "Duplicate Character"
         },
+        "addRelationship": {
+            "title": "Add Relationship",
+            "description": "Create a relationship between this character and another.",
+            "submit": "Add Relationship"
+        },
+        "assignItem": {
+            "title": "Assign Item",
+            "description": "Assign an item from the narrative module to this character.",
+            "submit": "Assign Item"
+        },
         "status": {
             "title": "Change Character Status",
             "description": "Select a new status for this character. Some transitions may be restricted.",
@@ -273,7 +283,9 @@
         "documentNameRequired": "Document name is required.",
         "documentUrlInvalid": "Please enter a valid Google Drive URL (docs.google.com, drive.google.com, etc.).",
         "fileTooLarge": "File must be 20 MB or smaller.",
-        "fileTypeNotAllowed": "This file type is not supported."
+        "fileTypeNotAllowed": "This file type is not supported.",
+        "targetRequired": "Please select a target character.",
+        "itemRequired": "Please select an item."
     },
     "notifications": {
         "created": "Character created successfully.",
@@ -287,11 +299,15 @@
         "abilityDeleted": "Ability deleted.",
         "attachmentAdded": "Document added.",
         "attachmentUpdated": "Document updated.",
-        "attachmentDeleted": "Document removed."
+        "attachmentDeleted": "Document removed.",
+        "relationshipAdded": "Relationship added successfully.",
+        "itemAssigned": "Item assigned successfully."
     },
     "errors": {
         "loadFailed": "Failed to load characters.",
         "notFound": "Character not found.",
-        "duplicateName": "A character with this name already exists in this event."
+        "duplicateName": "A character with this name already exists in this event.",
+        "relationshipFailed": "Failed to add relationship.",
+        "itemAssignFailed": "Failed to assign item."
     }
 }


### PR DESCRIPTION
## Changes

- Extract inline relationship and item assignment forms into dedicated modal dialog components
- Add `AddRelationshipDialog` component with 4-field form (target character, type, mode, description)
- Add `AssignItemDialog` component with 2-field form (item selection, notes)
- Simplify `CharacterRelationshipsPanel` and `CharacterItemsPanel` by removing form UI logic
- Update both panels to use compact `+` button next to section titles to trigger dialogs
- Add combobox picker for character and item selection with `modal={false}` to prevent focus conflicts
- Update i18n messages (EN, CS) with new dialog titles, descriptions, validation messages, and toast notifications
- Add UI implementation guidelines documenting the "Section Title with Modal Action Pattern"

## Benefits

- **Cleaner panels**: Parent components focus on displaying lists, not managing form state
- **Reduced vertical space**: Inline forms replaced with compact icon buttons
- **Better UX**: Modal dialogs provide focused input experience
- **Reusable pattern**: Establishes guidelines for similar add-to-list workflows