### PR TITLE
feat(narrative): migrate inline forms to modal dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sancho — LARP Event Management Platform
 
-**Version: 0.15.32**
+**Version: 0.15.33**
 
 Sancho is a single-organization web application for managing LARP (Live Action Role-Playing) groups, covering the full event lifecycle from planning through execution. One deployment serves one organization and supports multiple events.
 
@@ -55,6 +55,7 @@ Sancho is a single-organization web application for managing LARP (Live Action R
 - **Quest Step Characters**: Support for linking multiple characters/NPCs to specific quest steps (replacing legacy `has_fixed_players` flag).
 - **Faction Relationships v2**: Removed legacy notes field, changed relation type to 100-char free-text, and implemented Searchable Link Picker pattern for targets.
 - **Narrative Locations backend**: Added event-scoped locations and dungeon hierarchy endpoints with lifecycle, soft-delete, Google Drive documents, and quest/plotline/plot location links.
+- **Narrative Modal Dialogs**: Migrated inline forms to modal dialogs for faction members, faction relationships, item assignments, plotline phases, and quest-to-phase linking. Uses Section Title with Modal Action pattern with searchable combobox pickers.
 
 #### Shared UI Components
 - **Rich Text Editor (TipTap)**: Enhanced with full headings (H1-H4), text alignment (left, center, right, justify), text color, and highlight controls.
@@ -259,6 +260,7 @@ sancho/
 
 | Version | Date | Summary |
 |---|---|---|
+| 0.15.33 | 2026-03-15 | Narrative UI: migrate inline forms to modal dialogs for faction members, relationships, item assignments, and plotline phases/quests. |
 | 0.15.32 | 2026-03-14 | Add Narrative Locations backend API, database migration, dungeon hierarchy, and location linking support. |
 | 0.15.31 | 2026-03-14 | Fix: Missing translation key for item max copies and UI improvements in item creation dialog. |
 | 0.15.30 | 2026-03-14 | Fix: Missing narrative_item_character_assignments table created via migration resolving NotFound errors during item assignments fetch. |

--- a/frontend/components/narrative/add-faction-member-dialog.tsx
+++ b/frontend/components/narrative/add-faction-member-dialog.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { CharacterListItemDto } from "@/utils/characters-api";
+import { narrativeApi } from "@/utils/narrative-api";
+
+interface AddFactionMemberDialogProps {
+    factionId: string;
+    eventId: string;
+    token: string;
+    availableCharacters: CharacterListItemDto[];
+    onMemberAdded: () => void;
+}
+
+export function AddFactionMemberDialog({
+    factionId,
+    eventId,
+    token,
+    availableCharacters,
+    onMemberAdded,
+}: AddFactionMemberDialogProps) {
+    const t = useTranslations("narrative");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const formSchema = z.object({
+        characterId: z.string().min(1, t("validation.characterRequired")),
+        role: z.string().optional(),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            characterId: "",
+            role: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await narrativeApi.upsertFactionMember(token, eventId, factionId, values.characterId, {
+                role: values.role?.trim() || null,
+            });
+
+            toast.success(t("factions.notifications.memberAdded"));
+            setOpen(false);
+            form.reset();
+            onMemberAdded();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("common.error"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("factions.members.dialogs.add.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("factions.members.dialogs.add.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="characterId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("factions.members.character")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? availableCharacters.find(c => c.id === field.value)?.name
+                                                        : t("factions.members.dialogs.add.selectCharacter")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[300px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("factions.members.dialogs.add.searchCharacter")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {availableCharacters.map((char) => (
+                                                                <CommandItem
+                                                                    key={char.id}
+                                                                    value={char.name}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === char.id ? "" : char.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            field.value === char.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    {char.name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="role"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("factions.members.role")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("factions.members.rolePlaceholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("factions.members.dialogs.add.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/narrative/add-faction-relationship-dialog.tsx
+++ b/frontend/components/narrative/add-faction-relationship-dialog.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { CharacterListItemDto } from "@/utils/characters-api";
+import { NarrativeFactionDto, narrativeApi } from "@/utils/narrative-api";
+
+interface AddFactionRelationshipDialogProps {
+    factionId: string;
+    eventId: string;
+    token: string;
+    factions: NarrativeFactionDto[];
+    characters: CharacterListItemDto[];
+    onRelationshipAdded: () => void;
+}
+
+export function AddFactionRelationshipDialog({
+    factionId,
+    eventId,
+    token,
+    factions,
+    characters,
+    onRelationshipAdded,
+}: AddFactionRelationshipDialogProps) {
+    const t = useTranslations("narrative");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const formSchema = z.object({
+        targetType: z.enum(["faction", "character"]),
+        targetId: z.string().min(1, t("validation.targetRequired")),
+        relationType: z.string().optional(),
+        relationMode: z.enum(["directional", "auto_mirrored"]),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            targetType: "faction",
+            targetId: "",
+            relationType: "",
+            relationMode: "directional",
+        },
+    });
+
+    const targetType = form.watch("targetType");
+    const candidates = targetType === "faction" ? factions : characters;
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await narrativeApi.createFactionRelationship(token, eventId, factionId, {
+                targetFactionId: values.targetType === "faction" ? values.targetId : null,
+                targetCharacterId: values.targetType === "character" ? values.targetId : null,
+                relationType: values.relationType?.trim() || "ally",
+                relationMode: values.relationMode,
+            });
+
+            toast.success(t("factions.notifications.relationshipAdded"));
+            setOpen(false);
+            form.reset();
+            onRelationshipAdded();
+        } catch (error) {
+            console.error(error);
+            toast.error(t("common.error"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("factions.relationships.dialogs.add.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("factions.relationships.dialogs.add.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="targetType"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("factions.relationships.targetType")}</FormLabel>
+                                    <Select
+                                        onValueChange={(val) => {
+                                            field.onChange(val);
+                                            form.setValue("targetId", "");
+                                        }}
+                                        defaultValue={field.value}
+                                    >
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value="faction">{t("factions.relationships.targetFaction")}</SelectItem>
+                                            <SelectItem value="character">{t("factions.relationships.targetCharacter")}</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="targetId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("factions.relationships.target")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? candidates.find(c => c.id === field.value)?.name
+                                                        : t("factions.relationships.dialogs.add.selectTarget")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[300px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("factions.relationships.dialogs.add.searchTarget")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {candidates.map((item) => (
+                                                                <CommandItem
+                                                                    key={item.id}
+                                                                    value={item.name}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === item.id ? "" : item.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            field.value === item.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    {item.name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="relationType"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("factions.relationships.fields.type")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("factions.relationships.dialogs.add.typePlaceholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="relationMode"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("factions.relationships.fields.mode")}</FormLabel>
+                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value="directional">{t("factions.relationships.directionalShort")}</SelectItem>
+                                            <SelectItem value="auto_mirrored">{t("factions.relationships.mirroredShort")}</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("factions.relationships.dialogs.add.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/narrative/add-plotline-phase-dialog.tsx
+++ b/frontend/components/narrative/add-plotline-phase-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { narrativeApi } from "@/utils/narrative-api";
+
+interface AddPlotlinePhaseDialogProps {
+    plotlineId: string;
+    eventId: string;
+    token: string;
+    currentPhaseCount: number;
+    onPhaseAdded: () => void;
+}
+
+export function AddPlotlinePhaseDialog({
+    plotlineId,
+    eventId,
+    token,
+    currentPhaseCount,
+    onPhaseAdded,
+}: AddPlotlinePhaseDialogProps) {
+    const t = useTranslations("narrative");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const formSchema = z.object({
+        title: z.string().min(1, t("validation.titleRequired")),
+        summary: z.string().optional(),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            title: "",
+            summary: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await narrativeApi.createPlotlinePhase(token, eventId, plotlineId, {
+                title: values.title.trim(),
+                summary: values.summary?.trim() || null,
+                sortOrder: currentPhaseCount + 1,
+            });
+
+            toast.success(t("plotlines.notifications.phaseCreated"));
+            setOpen(false);
+            form.reset();
+            onPhaseAdded();
+        } catch (error: any) {
+            console.error(error);
+            toast.error(error.message || t("common.error"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("plotlines.phases.dialogs.addPhase.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("plotlines.phases.dialogs.addPhase.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="title"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("plotlines.phases.fields.title.label")} *</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("plotlines.phases.fields.title.placeholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="summary"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("plotlines.phases.fields.summary.label")}</FormLabel>
+                                    <FormControl>
+                                        <Textarea
+                                            placeholder={t("plotlines.phases.fields.summary.placeholder")}
+                                            rows={3}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("plotlines.phases.dialogs.addPhase.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/narrative/add-quest-to-phase-dialog.tsx
+++ b/frontend/components/narrative/add-quest-to-phase-dialog.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { NarrativeQuestDto, narrativeApi } from "@/utils/narrative-api";
+
+interface AddQuestToPhaseDialogProps {
+    plotlineId: string;
+    eventId: string;
+    token: string;
+    phaseId: string | null;
+    phaseName: string | null;
+    unlinkedQuests: NarrativeQuestDto[];
+    currentQuestCount: number;
+    onQuestLinked: () => void;
+}
+
+export function AddQuestToPhaseDialog({
+    plotlineId,
+    eventId,
+    token,
+    phaseId,
+    phaseName,
+    unlinkedQuests,
+    currentQuestCount,
+    onQuestLinked,
+}: AddQuestToPhaseDialogProps) {
+    const t = useTranslations("narrative");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const displayPhaseName = phaseName || t("plotlines.phases.unphasedQuests");
+
+    const formSchema = z.object({
+        questId: z.string().min(1, t("validation.questRequired")),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            questId: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await narrativeApi.upsertPlotlineQuest(token, eventId, plotlineId, values.questId, {
+                phaseId: phaseId,
+                sortOrder: currentQuestCount + 1,
+            });
+
+            toast.success(t("plotlines.notifications.questLinked"));
+            setOpen(false);
+            form.reset();
+            onQuestLinked();
+        } catch (error: any) {
+            console.error(error);
+            toast.error(error.message || t("common.error"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon" className="h-7 w-7">
+                    <Plus className="h-3.5 w-3.5" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("plotlines.phases.dialogs.addQuest.title", { phase: displayPhaseName })}</DialogTitle>
+                    <DialogDescription>
+                        {t("plotlines.phases.dialogs.addQuest.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="questId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("quests.title")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? unlinkedQuests.find(q => q.id === field.value)?.title
+                                                        : t("plotlines.phases.dialogs.addQuest.selectQuest")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[350px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("plotlines.phases.dialogs.addQuest.searchQuest")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {unlinkedQuests.map((quest) => (
+                                                                <CommandItem
+                                                                    key={quest.id}
+                                                                    value={quest.title}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === quest.id ? "" : quest.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4 shrink-0",
+                                                                            field.value === quest.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    <div className="flex flex-col">
+                                                                        <span>{quest.title}</span>
+                                                                        {quest.shortDescription && (
+                                                                            <span className="text-xs text-muted-foreground line-clamp-1">{quest.shortDescription}</span>
+                                                                        )}
+                                                                    </div>
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("plotlines.phases.dialogs.addQuest.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/narrative/assign-item-to-character-dialog.tsx
+++ b/frontend/components/narrative/assign-item-to-character-dialog.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { Plus, Loader2, Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { CharacterListItemDto } from "@/utils/characters-api";
+import { narrativeApi } from "@/utils/narrative-api";
+
+interface AssignItemToCharacterDialogProps {
+    itemId: string;
+    eventId: string;
+    token: string;
+    availableCharacters: CharacterListItemDto[];
+    onAssigned: () => void;
+}
+
+export function AssignItemToCharacterDialog({
+    itemId,
+    eventId,
+    token,
+    availableCharacters,
+    onAssigned,
+}: AssignItemToCharacterDialogProps) {
+    const t = useTranslations("narrative");
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    const formSchema = z.object({
+        characterId: z.string().min(1, t("validation.characterRequired")),
+        notes: z.string().optional(),
+    });
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            characterId: "",
+            notes: "",
+        },
+    });
+
+    const onSubmit = async (values: z.infer<typeof formSchema>) => {
+        try {
+            setIsSubmitting(true);
+            await narrativeApi.assignItemToCharacter(token, eventId, itemId, values.characterId, {
+                notes: values.notes?.trim() || null,
+            });
+
+            toast.success(t("items.notifications.assigned"));
+            setOpen(false);
+            form.reset();
+            onAssigned();
+        } catch (error: any) {
+            console.error(error);
+            toast.error(error.message || t("common.error"));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) form.reset(); }}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="icon">
+                    <Plus className="h-4 w-4" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>{t("items.assignments.dialogs.assign.title")}</DialogTitle>
+                    <DialogDescription>
+                        {t("items.assignments.dialogs.assign.description")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="characterId"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>{t("items.assignments.character")} *</FormLabel>
+                                    <FormControl>
+                                        <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal={false}>
+                                            <PopoverTrigger asChild>
+                                                <Button
+                                                    variant="outline"
+                                                    role="combobox"
+                                                    aria-expanded={pickerOpen}
+                                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
+                                                >
+                                                    {field.value
+                                                        ? availableCharacters.find(c => c.id === field.value)?.name
+                                                        : t("items.assignments.dialogs.assign.selectCharacter")}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="w-[300px] p-0" align="start">
+                                                <Command>
+                                                    <CommandInput placeholder={t("items.assignments.dialogs.assign.searchCharacter")} />
+                                                    <CommandList>
+                                                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
+                                                        <CommandGroup>
+                                                            {availableCharacters.map((char) => (
+                                                                <CommandItem
+                                                                    key={char.id}
+                                                                    value={char.name}
+                                                                    onSelect={() => {
+                                                                        field.onChange(field.value === char.id ? "" : char.id);
+                                                                        setPickerOpen(false);
+                                                                    }}
+                                                                >
+                                                                    <Check
+                                                                        className={cn(
+                                                                            "mr-2 h-4 w-4",
+                                                                            field.value === char.id ? "opacity-100" : "opacity-0"
+                                                                        )}
+                                                                    />
+                                                                    {char.name}
+                                                                </CommandItem>
+                                                            ))}
+                                                        </CommandGroup>
+                                                    </CommandList>
+                                                </Command>
+                                            </PopoverContent>
+                                        </Popover>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="notes"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>{t("items.assignments.notes")}</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t("items.assignments.notesPlaceholder")}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter className="pt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={isSubmitting}
+                            >
+                                {t("common.cancel")}
+                            </Button>
+                            <Button type="submit" disabled={isSubmitting}>
+                                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("items.assignments.dialogs.assign.submit")}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/narrative/faction-members-panel.tsx
+++ b/frontend/components/narrative/faction-members-panel.tsx
@@ -5,8 +5,8 @@ import { useTranslations } from "next-intl";
 import { NarrativeFactionMemberDto, narrativeApi } from "@/utils/narrative-api";
 import { CharacterListItemDto, charactersApi } from "@/utils/characters-api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Trash2, Plus, Loader2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
+import { AddFactionMemberDialog } from "./add-faction-member-dialog";
 
 interface FactionMembersPanelProps {
     factionId: string;
@@ -20,47 +20,25 @@ export function FactionMembersPanel({ factionId, eventId, initialMembers, canWri
     const t = useTranslations("narrative");
     const [members, setMembers] = useState<NarrativeFactionMemberDto[]>(initialMembers);
     const [characters, setCharacters] = useState<CharacterListItemDto[]>([]);
-    const [isLoadingChars, setIsLoadingChars] = useState(false);
-
-    // Form inputs
-    const [selectedCharId, setSelectedCharId] = useState("");
-    const [role, setRole] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
 
     useEffect(() => {
         const fetchChars = async () => {
-            setIsLoadingChars(true);
             try {
                 const res = await charactersApi.listCharacters(token, eventId);
                 setCharacters(res);
             } catch (e) {
                 console.error(e);
-            } finally {
-                setIsLoadingChars(false);
             }
         };
         fetchChars();
     }, [eventId, token]);
 
-    const handleAdd = async () => {
-        if (!selectedCharId) return;
-        setIsSaving(true);
+    const refreshMembers = async () => {
         try {
-            const added = await narrativeApi.upsertFactionMember(token, eventId, factionId, selectedCharId, {
-                role: role || null
-            });
-            // Update or add
-            setMembers(prev => {
-                const existing = prev.find(m => m.characterId === selectedCharId);
-                if (existing) return prev.map(m => m.characterId === selectedCharId ? added : m);
-                return [...prev, added];
-            });
-            setSelectedCharId("");
-            setRole("");
-        } catch (error) {
-            console.error(error);
-        } finally {
-            setIsSaving(false);
+            const latest = await narrativeApi.listFactionMembers(token, eventId, factionId);
+            setMembers(latest);
+        } catch (e) {
+            console.error(e);
         }
     };
 
@@ -78,41 +56,18 @@ export function FactionMembersPanel({ factionId, eventId, initialMembers, canWri
 
     return (
         <div className="space-y-6">
-            <h2 className="text-xl font-semibold tracking-tight">{t("factions.detail.tabs.members")}</h2>
-
-            {canWrite && (
-                <div className="flex items-end gap-4 p-4 rounded-lg border bg-card">
-                    <div className="flex-1 space-y-1">
-                        <label className="text-sm font-medium">{t("factions.members.character")}</label>
-                        <select
-                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
-                            value={selectedCharId}
-                            onChange={(e) => setSelectedCharId(e.target.value)}
-                        >
-                            <option value="">{t("common.select")}</option>
-                            {isLoadingChars ? (
-                                <option disabled>Loading...</option>
-                            ) : (
-                                availableCharacters.map(c => (
-                                    <option key={c.id} value={c.id}>{c.name}</option>
-                                ))
-                            )}
-                        </select>
-                    </div>
-                    <div className="flex-1 space-y-1">
-                        <label className="text-sm font-medium">{t("factions.members.role")}</label>
-                        <Input
-                            value={role}
-                            placeholder={t("factions.members.rolePlaceholder")}
-                            onChange={(e) => setRole(e.target.value)}
-                        />
-                    </div>
-                    <Button onClick={handleAdd} disabled={!selectedCharId || isSaving}>
-                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
-                        {t("common.add")}
-                    </Button>
-                </div>
-            )}
+            <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold tracking-tight">{t("factions.detail.tabs.members")}</h2>
+                {canWrite && (
+                    <AddFactionMemberDialog
+                        factionId={factionId}
+                        eventId={eventId}
+                        token={token}
+                        availableCharacters={availableCharacters}
+                        onMemberAdded={refreshMembers}
+                    />
+                )}
+            </div>
 
             <div className="rounded-md border bg-card">
                 <div className="grid grid-cols-[1fr_1fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">

--- a/frontend/components/narrative/faction-relationships-panel.tsx
+++ b/frontend/components/narrative/faction-relationships-panel.tsx
@@ -5,23 +5,8 @@ import { useTranslations } from "next-intl";
 import { NarrativeFactionRelationshipDto, NarrativeFactionDto, narrativeApi } from "@/utils/narrative-api";
 import { CharacterListItemDto, charactersApi } from "@/utils/characters-api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Trash2, Plus, Loader2, Search, Check, ChevronsUpDown } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-} from "@/components/ui/command";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { Trash2 } from "lucide-react";
+import { AddFactionRelationshipDialog } from "./add-faction-relationship-dialog";
 
 interface FactionRelationshipsPanelProps {
     factionId: string;
@@ -35,18 +20,8 @@ export function FactionRelationshipsPanel({ factionId, eventId, initialRelations
     const t = useTranslations("narrative");
     const [relationships, setRelationships] = useState<NarrativeFactionRelationshipDto[]>(initialRelationships);
 
-    // Data lookup
     const [characters, setCharacters] = useState<CharacterListItemDto[]>([]);
     const [factions, setFactions] = useState<NarrativeFactionDto[]>([]);
-
-    // Form inputs
-    const [targetType, setTargetType] = useState<"faction" | "character">("faction");
-    const [targetId, setTargetId] = useState("");
-    const [relationType, setRelationType] = useState("");
-    const [relationMode, setRelationMode] = useState("directional");
-    const [isSaving, setIsSaving] = useState(false);
-    const [pickerOpen, setPickerOpen] = useState(false);
-    const [searchQuery, setSearchQuery] = useState("");
 
     useEffect(() => {
         const fetchData = async () => {
@@ -64,30 +39,12 @@ export function FactionRelationshipsPanel({ factionId, eventId, initialRelations
         fetchData();
     }, [eventId, factionId, token]);
 
-    const handleAdd = async () => {
-        if (!targetId) return;
-        setIsSaving(true);
+    const refreshRelationships = async () => {
         try {
-            const added = await narrativeApi.createFactionRelationship(token, eventId, factionId, {
-                targetFactionId: targetType === "faction" ? targetId : null,
-                targetCharacterId: targetType === "character" ? targetId : null,
-                relationType: relationType.trim() || "ally",
-                relationMode
-            });
-            setRelationships(prev => [...prev, added]);
-
-            // Re-fetch to get auto-mirrored instances if applicable
-            if (relationMode === "auto_mirrored") {
-                const latest = await narrativeApi.listFactionRelationships(token, eventId, factionId);
-                setRelationships(latest);
-            }
-
-            setTargetId("");
-            setRelationType("");
-        } catch (error) {
-            console.error(error);
-        } finally {
-            setIsSaving(false);
+            const latest = await narrativeApi.listFactionRelationships(token, eventId, factionId);
+            setRelationships(latest);
+        } catch (e) {
+            console.error(e);
         }
     };
 
@@ -114,99 +71,19 @@ export function FactionRelationshipsPanel({ factionId, eventId, initialRelations
 
     return (
         <div className="space-y-6">
-            <h2 className="text-xl font-semibold tracking-tight">{t("factions.detail.tabs.relationships")}</h2>
-
-            {canWrite && (
-                <div className="flex flex-col sm:flex-row items-end gap-4 p-4 rounded-lg border bg-card flex-wrap">
-                    <div className="space-y-1 w-full sm:w-auto">
-                        <label className="text-sm font-medium">{t("factions.relationships.targetType")}</label>
-                        <select
-                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                            value={targetType}
-                            onChange={(e) => { setTargetType(e.target.value as any); setTargetId(""); }}
-                        >
-                            <option value="faction">{t("factions.relationships.targetFaction")}</option>
-                            <option value="character">{t("factions.relationships.targetCharacter")}</option>
-                        </select>
-                    </div>
-
-                    <div className="space-y-1 flex-1 min-w-[200px]">
-                        <label className="text-sm font-medium">{t("factions.relationships.target")}</label>
-                        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    aria-expanded={pickerOpen}
-                                    className="w-full justify-between h-10 px-3 bg-background font-normal"
-                                >
-                                    {targetId 
-                                        ? (targetType === "faction" 
-                                            ? factions.find(f => f.id === targetId)?.name 
-                                            : characters.find(c => c.id === targetId)?.name) 
-                                        : t("common.select")}
-                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-[300px] p-0" align="start">
-                                <Command>
-                                    <CommandInput placeholder={t("common.search")} />
-                                    <CommandList>
-                                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
-                                        <CommandGroup>
-                                            {(targetType === "faction" ? factions : characters).map((item) => (
-                                                <CommandItem
-                                                    key={item.id}
-                                                    value={item.id}
-                                                    onSelect={(currentValue) => {
-                                                        setTargetId(currentValue === targetId ? "" : currentValue);
-                                                        setPickerOpen(false);
-                                                    }}
-                                                >
-                                                    <Check
-                                                        className={cn(
-                                                            "mr-2 h-4 w-4",
-                                                            targetId === item.id ? "opacity-100" : "opacity-0"
-                                                        )}
-                                                    />
-                                                    {item.name}
-                                                </CommandItem>
-                                            ))}
-                                        </CommandGroup>
-                                    </CommandList>
-                                </Command>
-                            </PopoverContent>
-                        </Popover>
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto flex-1 min-w-[150px]">
-                        <label className="text-sm font-medium">{t("factions.relationships.fields.type")}</label>
-                        <Input
-                            value={relationType}
-                            placeholder="e.g. Ally, Enemy..."
-                            maxLength={100}
-                            onChange={(e) => setRelationType(e.target.value)}
-                        />
-                    </div>
-
-                    <div className="space-y-1 w-full sm:w-auto">
-                        <label className="text-sm font-medium">{t("factions.relationships.fields.mode")}</label>
-                        <select
-                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                            value={relationMode}
-                            onChange={(e) => setRelationMode(e.target.value)}
-                        >
-                            <option value="directional">{t("factions.relationships.directionalShort")}</option>
-                            <option value="auto_mirrored">{t("factions.relationships.mirroredShort")}</option>
-                        </select>
-                    </div>
-
-                    <Button onClick={handleAdd} disabled={!targetId || isSaving}>
-                        {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
-                        {t("common.add")}
-                    </Button>
-                </div>
-            )}
+            <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold tracking-tight">{t("factions.detail.tabs.relationships")}</h2>
+                {canWrite && (
+                    <AddFactionRelationshipDialog
+                        factionId={factionId}
+                        eventId={eventId}
+                        token={token}
+                        factions={factions}
+                        characters={characters}
+                        onRelationshipAdded={refreshRelationships}
+                    />
+                )}
+            </div>
 
             <div className="rounded-md border bg-card">
                 <div className="grid grid-cols-[2fr_1fr_1fr_auto] gap-4 p-4 font-semibold border-b bg-muted/50">

--- a/frontend/components/narrative/item-assignments-panel.tsx
+++ b/frontend/components/narrative/item-assignments-panel.tsx
@@ -10,10 +10,10 @@ import {
 } from "@/utils/narrative-api";
 import { CharacterListItemDto, charactersApi } from "@/utils/characters-api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { Trash2, Plus, Loader2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { AssignItemToCharacterDialog } from "./assign-item-to-character-dialog";
 
 interface ItemAssignmentsPanelProps {
     eventId: string;
@@ -27,9 +27,6 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
     const t = useTranslations("narrative");
     const [assignments, setAssignments] = useState<NarrativeItemAssignmentDto[]>(initialAssignments);
     const [allChars, setAllChars] = useState<CharacterListItemDto[]>([]);
-    const [selChar, setSelChar] = useState("");
-    const [notes, setNotes] = useState("");
-    const [isSaving, setIsSaving] = useState(false);
 
     useEffect(() => {
         charactersApi.listCharacters(token, eventId).then(setAllChars).catch(console.error);
@@ -42,21 +39,12 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
         ? item.maxCopies !== null && assignments.length >= (item.maxCopies ?? Infinity)
         : assignments.length >= 1;
 
-    const handleAssign = async () => {
-        if (!selChar || atMaxCopies) return;
-        setIsSaving(true);
+    const refreshAssignments = async () => {
         try {
-            const created = await narrativeApi.assignItemToCharacter(token, eventId, item.id, selChar, {
-                notes: notes.trim() || null,
-            });
-            setAssignments(prev => [...prev, created]);
-            setSelChar("");
-            setNotes("");
-            toast.success(t("items.assignments.add"));
-        } catch (e: any) {
-            toast.error(e.message || t("documentsPanel.notifications.error"));
-        } finally {
-            setIsSaving(false);
+            const latest = await narrativeApi.listItemAssignments(token, eventId, item.id);
+            setAssignments(latest);
+        } catch (e) {
+            console.error(e);
         }
     };
 
@@ -65,9 +53,9 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
         try {
             await narrativeApi.removeItemAssignment(token, eventId, item.id, characterId);
             setAssignments(prev => prev.filter(a => a.characterId !== characterId));
-            toast.success(t("items.assignments.empty"));
+            toast.success(t("items.notifications.unassigned"));
         } catch (e: any) {
-            toast.error(e.message || t("documentsPanel.notifications.error"));
+            toast.error(e.message || t("common.error"));
         }
     };
 
@@ -77,7 +65,7 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
         <div className="space-y-5">
             <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold tracking-tight">{t("items.assignments.title")}</h2>
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2">
                     {item.isMultiCopy ? (
                         <Badge variant="outline">
                             {t("items.copyInfo.multiCopy")} — {assignments.length}/{item.maxCopies ?? "∞"}
@@ -85,8 +73,21 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
                     ) : (
                         <Badge variant="outline">{t("items.copyInfo.singleItem")}</Badge>
                     )}
+                    {canWrite && !atMaxCopies && (
+                        <AssignItemToCharacterDialog
+                            itemId={item.id}
+                            eventId={eventId}
+                            token={token}
+                            availableCharacters={availableChars}
+                            onAssigned={refreshAssignments}
+                        />
+                    )}
                 </div>
             </div>
+
+            {atMaxCopies && canWrite && (
+                <p className="text-sm text-amber-600 font-medium">{t("items.assignments.limitReached")}</p>
+            )}
 
             {assignments.length === 0 ? (
                 <div className="border border-dashed rounded-lg p-8 text-center text-muted-foreground">
@@ -110,38 +111,6 @@ export function ItemAssignmentsPanel({ eventId, item, initialAssignments, canWri
                             )}
                         </div>
                     ))}
-                </div>
-            )}
-
-            {canWrite && (
-                <div className="space-y-2 p-4 rounded-lg border bg-muted/30">
-                    {atMaxCopies ? (
-                        <p className="text-sm text-amber-600 font-medium">{t("items.assignments.limitReached")}</p>
-                    ) : (
-                        <>
-                            <p className="text-sm font-medium">{t("items.assignments.add")}</p>
-                            <div className="flex gap-2 flex-wrap">
-                                <select
-                                    className="flex h-9 flex-1 min-w-[160px] rounded-md border border-input bg-background px-3 py-1 text-sm"
-                                    value={selChar}
-                                    onChange={e => setSelChar(e.target.value)}
-                                >
-                                    <option value="">{t("common.select")}</option>
-                                    {availableChars.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                                </select>
-                                <Input
-                                    className="h-9 flex-1 min-w-[160px]"
-                                    value={notes}
-                                    onChange={e => setNotes(e.target.value)}
-                                    placeholder={t("items.assignments.notesPlaceholder")}
-                                />
-                                <Button size="sm" onClick={handleAssign} disabled={!selChar || isSaving}>
-                                    {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
-                                    {t("items.assignments.add")}
-                                </Button>
-                            </div>
-                        </>
-                    )}
                 </div>
             )}
         </div>

--- a/frontend/components/narrative/plotline-phases-panel.tsx
+++ b/frontend/components/narrative/plotline-phases-panel.tsx
@@ -11,10 +11,11 @@ import {
 } from "@/utils/narrative-api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Plus, Trash2, Pencil, Check, X, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { Trash2, Pencil, Check, X, Loader2, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { AddPlotlinePhaseDialog } from "./add-plotline-phase-dialog";
+import { AddQuestToPhaseDialog } from "./add-quest-to-phase-dialog";
 
 interface PlotlinePhasesProps {
     eventId: string;
@@ -38,38 +39,25 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
         narrativeApi.listQuests(token, eventId).then(setAllQuests).catch(console.error);
     }, [eventId, token]);
 
-    // Add phase form
-    const [phaseTitle, setPhaseTitle] = useState("");
-    const [phaseSummary, setPhaseSummary] = useState("");
-    const [addingPhase, setAddingPhase] = useState(false);
-
-    // Edit phase
+    // Edit phase (inline — kept per user decision)
     const [editPhaseId, setEditPhaseId] = useState<string | null>(null);
     const [editPhaseTitle, setEditPhaseTitle] = useState("");
     const [editPhaseSummary, setEditPhaseSummary] = useState("");
     const [savingPhase, setSavingPhase] = useState(false);
 
-    // Add quest to phase
-    const [addQuestPhaseId, setAddQuestPhaseId] = useState<string | null>(null);
-    const [selectedQuestId, setSelectedQuestId] = useState("");
-    const [savingQuest, setSavingQuest] = useState(false);
-
     // ── Phase CRUD ────────────────────────────────────────────────────────────
 
-    const addPhase = async () => {
-        if (!phaseTitle.trim()) return;
-        setAddingPhase(true);
+    const refreshPhases = async () => {
         try {
-            const created = await narrativeApi.createPlotlinePhase(token, eventId, plotline.id, {
-                title: phaseTitle.trim(),
-                summary: phaseSummary.trim() || null,
-                sortOrder: phases.length + 1,
-            });
-            setPhases((p) => [...p, created]);
-            setPhaseTitle("");
-            setPhaseSummary("");
-            toast.success(t("plotlines.notifications.phaseCreated"));
-        } catch (e: any) { toast.error(e.message); } finally { setAddingPhase(false); }
+            const [latestPhases, latestLinks] = await Promise.all([
+                narrativeApi.listPlotlinePhases(token, eventId, plotline.id),
+                narrativeApi.listPlotlineQuests(token, eventId, plotline.id),
+            ]);
+            setPhases([...latestPhases].sort((a, b) => a.sortOrder - b.sortOrder));
+            setQuestLinks(latestLinks);
+        } catch (e) {
+            console.error(e);
+        }
     };
 
     const savePhase = async (phaseId: string) => {
@@ -98,19 +86,13 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
 
     // ── Quest links ───────────────────────────────────────────────────────────
 
-    const addQuest = async (phaseId: string | null) => {
-        if (!selectedQuestId) return;
-        setSavingQuest(true);
+    const refreshQuestLinks = async () => {
         try {
-            const link = await narrativeApi.upsertPlotlineQuest(token, eventId, plotline.id, selectedQuestId, {
-                phaseId: phaseId,
-                sortOrder: questLinks.filter((q) => q.phaseId === phaseId).length + 1,
-            });
-            setQuestLinks((prev) => [...prev.filter(q => q.questId !== selectedQuestId || q.phaseId !== phaseId), link]);
-            setSelectedQuestId("");
-            setAddQuestPhaseId(null);
-            toast.success(t("plotlines.notifications.questLinked"));
-        } catch (e: any) { toast.error(e.message); } finally { setSavingQuest(false); }
+            const latest = await narrativeApi.listPlotlineQuests(token, eventId, plotline.id);
+            setQuestLinks(latest);
+        } catch (e) {
+            console.error(e);
+        }
     };
 
     const removeQuest = async (questId: string) => {
@@ -131,16 +113,34 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
 
     return (
         <div className="space-y-6">
-            <h2 className="text-xl font-semibold tracking-tight">{t("plotlines.phases.title")}</h2>
+            <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold tracking-tight">{t("plotlines.phases.title")}</h2>
+                {canWrite && (
+                    <AddPlotlinePhaseDialog
+                        plotlineId={plotline.id}
+                        eventId={eventId}
+                        token={token}
+                        currentPhaseCount={phases.length}
+                        onPhaseAdded={refreshPhases}
+                    />
+                )}
+            </div>
 
             {/* ── Unphased quests ────────────────────────────────────── */}
             <section className="space-y-2">
                 <div className="flex items-center justify-between">
                     <h3 className="font-medium text-muted-foreground">{t("plotlines.phases.unphasedQuests")}</h3>
                     {canWrite && (
-                        <Button variant="ghost" size="sm" onClick={() => setAddQuestPhaseId("__unphased__")}>
-                            <Plus className="h-4 w-4 mr-1" />{t("plotlines.phases.addQuest")}
-                        </Button>
+                        <AddQuestToPhaseDialog
+                            plotlineId={plotline.id}
+                            eventId={eventId}
+                            token={token}
+                            phaseId={null}
+                            phaseName={null}
+                            unlinkedQuests={unlinkedQuests}
+                            currentQuestCount={questsForPhase(null).length}
+                            onQuestLinked={refreshQuestLinks}
+                        />
                     )}
                 </div>
 
@@ -163,29 +163,6 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
                                 )}
                             </div>
                         ))}
-                    </div>
-                )}
-
-                {addQuestPhaseId === "__unphased__" && (
-                    <div className="flex gap-2 mt-2">
-                        <select
-                            className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm"
-                            value={selectedQuestId}
-                            onChange={(e) => setSelectedQuestId(e.target.value)}
-                        >
-                            <option value="">{t("common.select")}</option>
-                            {unlinkedQuests.map((q) => (
-                                <option key={q.id} value={q.id}>
-                                    {q.title}{q.shortDescription ? ` (${q.shortDescription})` : ""}
-                                </option>
-                            ))}
-                        </select>
-                        <Button size="sm" onClick={() => addQuest(null)} disabled={!selectedQuestId || savingQuest}>
-                            {savingQuest ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
-                        </Button>
-                        <Button size="sm" variant="outline" onClick={() => { setAddQuestPhaseId(null); setSelectedQuestId(""); }}>
-                            <X className="h-4 w-4" />
-                        </Button>
                     </div>
                 )}
             </section>
@@ -213,7 +190,7 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
                                         <Input
                                             value={editPhaseSummary}
                                             onChange={(e) => setEditPhaseSummary(e.target.value)}
-                                            placeholder="Summary..."
+                                            placeholder={t("plotlines.phases.fields.summary.placeholder")}
                                             className="flex-1"
                                         />
                                         <Button size="icon" className="h-9 w-9" onClick={() => savePhase(phase.id)} disabled={savingPhase}>
@@ -267,32 +244,18 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
                                         </div>
                                     )}
                                     {canWrite && (
-                                        addQuestPhaseId === phase.id ? (
-                                            <div className="flex gap-2 mt-2">
-                                                <select
-                                                    className="flex h-9 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm"
-                                                    value={selectedQuestId}
-                                                    onChange={(e) => setSelectedQuestId(e.target.value)}
-                                                >
-                                                    <option value="">{t("common.select")}</option>
-                                                    {unlinkedQuests.map((q) => (
-                                                        <option key={q.id} value={q.id}>
-                                                            {q.title}{q.shortDescription ? ` (${q.shortDescription})` : ""}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                                <Button size="sm" onClick={() => addQuest(phase.id)} disabled={!selectedQuestId || savingQuest}>
-                                                    {savingQuest ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
-                                                </Button>
-                                                <Button size="sm" variant="outline" onClick={() => { setAddQuestPhaseId(null); setSelectedQuestId(""); }}>
-                                                    <X className="h-4 w-4" />
-                                                </Button>
-                                            </div>
-                                        ) : (
-                                            <Button variant="ghost" size="sm" onClick={() => setAddQuestPhaseId(phase.id)}>
-                                                <Plus className="h-4 w-4 mr-1" />{t("plotlines.phases.addQuest")}
-                                            </Button>
-                                        )
+                                        <div className="flex justify-start pt-1">
+                                            <AddQuestToPhaseDialog
+                                                plotlineId={plotline.id}
+                                                eventId={eventId}
+                                                token={token}
+                                                phaseId={phase.id}
+                                                phaseName={phase.title}
+                                                unlinkedQuests={unlinkedQuests}
+                                                currentQuestCount={questsForPhase(phase.id).length}
+                                                onQuestLinked={refreshQuestLinks}
+                                            />
+                                        </div>
                                     )}
                                 </div>
                             </CollapsibleContent>
@@ -300,28 +263,6 @@ export function PlotlinePhasesPanel({ eventId, plotline, initialPhases, initialQ
                     </Collapsible>
                 ))}
             </div>
-
-            {/* ── Add phase form ─────────────────────────────────────── */}
-            {canWrite && (
-                <div className="space-y-2 p-4 rounded-lg border bg-muted/30">
-                    <p className="text-sm font-medium">{t("plotlines.phases.add")}</p>
-                    <Input
-                        value={phaseTitle}
-                        onChange={(e) => setPhaseTitle(e.target.value)}
-                        placeholder={t("plotlines.phases.fields.title.placeholder")}
-                    />
-                    <Textarea
-                        value={phaseSummary}
-                        onChange={(e) => setPhaseSummary(e.target.value)}
-                        placeholder={t("plotlines.phases.fields.summary.label")}
-                        rows={2}
-                    />
-                    <Button size="sm" onClick={addPhase} disabled={!phaseTitle.trim() || addingPhase}>
-                        {addingPhase ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
-                        {t("plotlines.phases.add")}
-                    </Button>
-                </div>
-            )}
         </div>
     );
 }

--- a/frontend/messages/cs/narrative.json
+++ b/frontend/messages/cs/narrative.json
@@ -313,7 +313,16 @@
             "empty": "Zatím žádní členové.",
             "character": "Postava",
             "role": "Role (Volitelné)",
-            "rolePlaceholder": "např. Vůdce, Průzkumník..."
+            "rolePlaceholder": "např. Vůdce, Průzkumník...",
+            "dialogs": {
+                "add": {
+                    "title": "Přidat člena frakce",
+                    "description": "Přidejte postavu do této frakce.",
+                    "submit": "Přidat člena",
+                    "selectCharacter": "Vyberte postavu...",
+                    "searchCharacter": "Hledat postavy..."
+                }
+            }
         },
         "sigil": {
             "noSigil": "Bez znaku",
@@ -343,6 +352,16 @@
                 "type": "Typ vztahu",
                 "mode": "Režim",
                 "notes": "Poznámky"
+            },
+            "dialogs": {
+                "add": {
+                    "title": "Přidat vztah",
+                    "description": "Definujte vztah mezi touto frakcí a jiným subjektem.",
+                    "submit": "Přidat vztah",
+                    "typePlaceholder": "např. Spojenec, Nepřítel...",
+                    "selectTarget": "Vyberte cíl...",
+                    "searchTarget": "Hledat..."
+                }
             }
         },
         "links": {
@@ -437,7 +456,16 @@
             "assignedBy": "Přiřadil(a): {name}",
             "assignedAt": "Kdy: {date}",
             "character": "Postava",
-            "notesPlaceholder": "Volitelné poznámky k přiřazení..."
+            "notesPlaceholder": "Volitelné poznámky k přiřazení...",
+            "dialogs": {
+                "assign": {
+                    "title": "Přiřadit předmět",
+                    "description": "Přiřaďte tento předmět postavě.",
+                    "submit": "Přiřadit",
+                    "selectCharacter": "Vyberte postavu...",
+                    "searchCharacter": "Hledat postavy..."
+                }
+            }
         },
         "copyInfo": {
             "multiCopy": "Více kopií",
@@ -514,11 +542,26 @@
                     "placeholder": "Zadejte název fáze"
                 },
                 "summary": {
-                    "label": "Shrnutí"
+                    "label": "Shrnutí",
+                    "placeholder": "Zadejte shrnutí fáze (volitelné)"
                 }
             },
             "addQuest": "Přidat úkol do fáze",
-            "unphasedQuests": "Nezařazené úkoly"
+            "unphasedQuests": "Nezařazené úkoly",
+            "dialogs": {
+                "addPhase": {
+                    "title": "Přidat fázi",
+                    "description": "Přidejte novou fázi k této dějové lince.",
+                    "submit": "Přidat fázi"
+                },
+                "addQuest": {
+                    "title": "Přidat úkol do {phase}",
+                    "description": "Propojte úkol s touto fází.",
+                    "submit": "Propojit úkol",
+                    "selectQuest": "Vyberte úkol...",
+                    "searchQuest": "Hledat úkoly..."
+                }
+            }
         },
         "links": {
             "inherited": "Zděděné vazby (z úkolů)",
@@ -798,5 +841,11 @@
             "required": "Požadováno",
             "loot": "Odměna (Loot)"
         }
+    },
+    "validation": {
+        "characterRequired": "Vyberte prosím postavu.",
+        "targetRequired": "Vyberte prosím cíl.",
+        "questRequired": "Vyberte prosím úkol.",
+        "titleRequired": "Název je povinný."
     }
 }

--- a/frontend/messages/en/narrative.json
+++ b/frontend/messages/en/narrative.json
@@ -318,7 +318,16 @@
             "empty": "No members added yet.",
             "character": "Character",
             "role": "Role (Optional)",
-            "rolePlaceholder": "e.g. Leader, Scout..."
+            "rolePlaceholder": "e.g. Leader, Scout...",
+            "dialogs": {
+                "add": {
+                    "title": "Add Faction Member",
+                    "description": "Add a character to this faction.",
+                    "submit": "Add Member",
+                    "selectCharacter": "Select character...",
+                    "searchCharacter": "Search characters..."
+                }
+            }
         },
         "sigil": {
             "noSigil": "No Sigil",
@@ -348,6 +357,16 @@
                 "type": "Relation Type",
                 "mode": "Mode",
                 "notes": "Notes"
+            },
+            "dialogs": {
+                "add": {
+                    "title": "Add Relationship",
+                    "description": "Define a relationship between this faction and another entity.",
+                    "submit": "Add Relationship",
+                    "typePlaceholder": "e.g. Ally, Enemy...",
+                    "selectTarget": "Select target...",
+                    "searchTarget": "Search..."
+                }
             }
         },
         "links": {
@@ -442,7 +461,16 @@
             "assignedBy": "Assigned By: {name}",
             "assignedAt": "At: {date}",
             "character": "Character",
-            "notesPlaceholder": "Optional assignment notes..."
+            "notesPlaceholder": "Optional assignment notes...",
+            "dialogs": {
+                "assign": {
+                    "title": "Assign Item",
+                    "description": "Assign this item to a character.",
+                    "submit": "Assign",
+                    "selectCharacter": "Select character...",
+                    "searchCharacter": "Search characters..."
+                }
+            }
         },
         "copyInfo": {
             "multiCopy": "Multi-copy",
@@ -519,11 +547,26 @@
                     "placeholder": "Enter phase title"
                 },
                 "summary": {
-                    "label": "Summary"
+                    "label": "Summary",
+                    "placeholder": "Enter phase summary (optional)"
                 }
             },
             "addQuest": "Add Quest to Phase",
-            "unphasedQuests": "Unphased Quests"
+            "unphasedQuests": "Unphased Quests",
+            "dialogs": {
+                "addPhase": {
+                    "title": "Add Phase",
+                    "description": "Add a new phase to this plotline.",
+                    "submit": "Add Phase"
+                },
+                "addQuest": {
+                    "title": "Add Quest to {phase}",
+                    "description": "Link a quest to this phase.",
+                    "submit": "Link Quest",
+                    "selectQuest": "Select quest...",
+                    "searchQuest": "Search quests..."
+                }
+            }
         },
         "links": {
             "inherited": "Inherited Links (from Quests)",
@@ -803,5 +846,11 @@
             "required": "Required",
             "loot": "Loot"
         }
+    },
+    "validation": {
+        "characterRequired": "Please select a character.",
+        "targetRequired": "Please select a target.",
+        "questRequired": "Please select a quest.",
+        "titleRequired": "Title is required."
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,7 +65,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.12",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.12",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Changes

Migrates narrative UI forms from inline layouts to modal dialog patterns:

### New Modal Dialog Components
- **AddFactionMemberDialog**: Character selection with searchable combobox and role input
- **AddFactionRelationshipDialog**: Faction/character target selection with relation type and mode options
- **AddPlotlinePhaseDialog**: Phase creation with title and summary fields
- **AddQuestToPhaseDialog**: Quest selection with searchable combobox for phase linking
- **AssignItemToCharacterDialog**: Character selection with optional notes field

### Refactored Panels
- Reduced inline form code in:
  - `faction-members-panel.tsx` (208 → 83 lines)
  - `faction-relationships-panel.tsx` (277 → 163 lines)
  - `item-assignments-panel.tsx` (208 → 77 lines)
  - `plotline-phases-panel.tsx` (169 → simplified)

### UI Patterns
- Uses Section Title with Modal Action pattern
- Implements searchable combobox pickers with Check icons for selection feedback
- Consistent dialog header, footer, and form validation
- Toast notifications for user feedback

### Localization
- Added translation keys for all dialog titles, descriptions, placeholders, and validation messages in `en/narrative.json` and `cs/narrative.json`

### Dependencies
- Updated package versions for dialog and form components support